### PR TITLE
wait-for-it.sh => updated to latest version to fix warnings

### DIFF
--- a/services/api/scripts/wait-for-it.sh
+++ b/services/api/scripts/wait-for-it.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#   Use this script to test if a given TCP host/port are available
+# Use this script to test if a given TCP host/port are available
 
 WAITFORIT_cmdname=${0##*/}
 
@@ -141,16 +141,20 @@ WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
 WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
 WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
 
-# check to see if timeout is from busybox?
+# Check to see if timeout is from busybox?
 WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
 WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
-if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
-        WAITFORIT_ISBUSY=1
-        WAITFORIT_BUSYTIMEFLAG="-t"
 
+WAITFORIT_BUSYTIMEFLAG=""
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+    WAITFORIT_ISBUSY=1
+    # Check if busybox timeout uses -t flag
+    # (recent Alpine versions don't support -t anymore)
+    if timeout &>/dev/stdout | grep -q -e '-t '; then
+        WAITFORIT_BUSYTIMEFLAG="-t"
+    fi
 else
-        WAITFORIT_ISBUSY=0
-        WAITFORIT_BUSYTIMEFLAG=""
+    WAITFORIT_ISBUSY=0
 fi
 
 if [[ $WAITFORIT_CHILD -gt 0 ]]; then


### PR DESCRIPTION
fixes warning about busybox

```
api_1       | timeout: unrecognized option: t
api_1       | BusyBox v1.31.1 () multi-call binary.
api_1       |
api_1       | Usage: timeout [-s SIG] SECS PROG ARGS
api_1       |
api_1       | Runs PROG. Sends SIG to it if it is not gone in SECS seconds.
api_1       | Default SIG: TERM.
api_1       | wait-for-it.sh: timeout occurred after waiting 15 seconds for mongo:27017
api_1       | yarn run v1.22.4
```

