### PR TITLE
updated mongo to use unified topology

### DIFF
--- a/services/api/src/database.js
+++ b/services/api/src/database.js
@@ -8,10 +8,7 @@ module.exports = async () => {
     useFindAndModify: false,
     useNewUrlParser: true,
     useCreateIndex: true,
-    // sets how many times to try reconnecting
-    reconnectTries: Number.MAX_VALUE,
-    // sets the delay between every retry (milliseconds)
-    reconnectInterval: 2000
+    useUnifiedTopology: true,
   });
   const db = mongoose.connection;
   db.on('error', console.error.bind(console, 'connection error:'));

--- a/services/api/src/test-helpers/index.js
+++ b/services/api/src/test-helpers/index.js
@@ -13,12 +13,10 @@ exports.setupDb = () =>
   new Promise((resolve) => {
     mongoServer.getConnectionString().then((mongoUri) => {
       const mongooseOpts = {
-        autoReconnect: true,
-        reconnectTries: Number.MAX_VALUE,
-        reconnectInterval: 1000,
         useNewUrlParser: true,
         useCreateIndex: true,
-        useFindAndModify: false
+        useFindAndModify: false,
+        useUnifiedTopology: true,
       };
 
       mongoose.connect(mongoUri, mongooseOpts);


### PR DESCRIPTION
Mongo seems to have updated its node driver to use a new topolgy design and we're getting deprecation warnings that the "reconnect" flags we're using appear to be outdated. This seems like it will be a lot more stable for us.

References:

http://mongodb.github.io/node-mongodb-native/3.3/reference/unified-topology/
https://stackoverflow.com/questions/59491225/how-to-connect-from-nodejs-to-mongodb-using-unified-topology-and-promises