### PR TITLE
Authentication ideas

### DIFF
--- a/services/api/src/middlewares/__tests__/authenticate.js
+++ b/services/api/src/middlewares/__tests__/authenticate.js
@@ -13,9 +13,6 @@ describe('authenticate', () => {
     ctx = context({ headers: { authorization: 'not Bearer $token' } });
     await expect(middleware(ctx)).rejects.toHaveProperty('message', 'no jwt token found in request');
 
-    const customTokenLocation = authenticate({}, { getToken: () => null });
-    ctx = context({ headers: { authorization: 'Bearer $token' } });
-    await expect(customTokenLocation(ctx)).rejects.toHaveProperty('message', 'no jwt token found in request');
   });
 
   it('should trigger an error if token is bad', async () => {
@@ -25,8 +22,6 @@ describe('authenticate', () => {
     await expect(middleware(ctx)).rejects.toHaveProperty('message', 'bad jwt token');
     ctx = context({});
 
-    const customTokenLocation = authenticate({}, { getToken: () => 'bad token' });
-    await expect(customTokenLocation(ctx)).rejects.toHaveProperty('message', 'bad jwt token');
   });
 
   it('should confirm that token has a valid kid', async () => {

--- a/services/api/src/middlewares/authenticate.js
+++ b/services/api/src/middlewares/authenticate.js
@@ -40,9 +40,9 @@ function validateToken(ctx, token, type) {
   return payload;
 }
 
-exports.authenticate = ({ type } = {}, options = {}) => {
+exports.authenticate = ({ type } = {}) => {
   return async (ctx, next) => {
-    const token = options.getToken ? options.getToken(ctx) : getToken(ctx);
+    const token = getToken(ctx);
     if (!token) ctx.throw(400, 'no jwt token found in request');
 
     const payload = validateToken(ctx, token, type);

--- a/services/api/src/middlewares/authenticate.js
+++ b/services/api/src/middlewares/authenticate.js
@@ -40,20 +40,25 @@ function validateToken(ctx, token, type) {
   return payload;
 }
 
-exports.authenticate = ({ type } = {}) => {
+exports.authenticate = ({ type, optional = false } = {}) => {
   return async (ctx, next) => {
-    const token = getToken(ctx);
-    if (!token) ctx.throw(400, 'no jwt token found in request');
-
-    const payload = validateToken(ctx, token, type);
-    ctx.state.jwt = payload;
+    if (!ctx.state.jwt) {
+      const token = getToken(ctx);
+      if (token) {
+        ctx.state.jwt = validateToken(ctx, token, type);
+      } else if (!optional) {
+        ctx.throw(400, 'no jwt token found in request');
+      }
+    }
     return next();
   };
 };
 
 exports.fetchUser = async (ctx, next) => {
-  ctx.state.authUser = await User.findById(ctx.state.jwt.userId);
-  if (!ctx.state.authUser) ctx.throw(400, 'user associated to token could not not be found');
+  if (!ctx.state.authUser) {
+    ctx.state.authUser = await User.findById(ctx.state.jwt.userId);
+    if (!ctx.state.authUser) ctx.throw(400, 'user associated to token could not not be found');
+  }
   await next();
 };
 

--- a/services/api/src/test-helpers/request.js
+++ b/services/api/src/test-helpers/request.js
@@ -6,8 +6,8 @@ const path = require('path');
 const tokens = require('../lib/tokens');
 
 module.exports = async function handleRequest(httpMethod, url, bodyOrQuery = {}, options = {}) {
-  const headers = {};
-  if (options.user) {
+  const headers = options.headers || {};
+  if (options.user && !headers.Authorization) {
     headers.Authorization = `Bearer ${tokens.createUserToken(options.user)}`;
   }
 

--- a/services/api/src/v1/__tests__/auth.js
+++ b/services/api/src/v1/__tests__/auth.js
@@ -71,10 +71,15 @@ describe('/1/users', () => {
     it('it should allow a user to set a password', async () => {
       const user = await createUser();
       const password = 'very new password';
+      const token = tokens.createUserTemporaryToken({ userId: user._id }, 'password');
       const response = await request('POST', '/1/auth/set-password', {
         password,
-        token: tokens.createUserTemporaryToken({ userId: user._id }, 'password'),
+      }, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        }
       });
+
       expect(response.status).toBe(200);
 
       const { payload } = jwt.decode(response.body.data.token, { complete: true });
@@ -89,7 +94,10 @@ describe('/1/users', () => {
       const password = 'very new password';
       const response = await request('POST', '/1/auth/set-password', {
         password,
-        token: 'some bad token not really a good token',
+      }, {
+        headers: {
+          Authorization: 'Bearer badtoken',
+        }
       });
       expect(response.status).toBe(400);
       expect(response.body).toEqual({ error: { message: 'bad jwt token', status: 400 } });

--- a/services/api/src/v1/auth.js
+++ b/services/api/src/v1/auth.js
@@ -74,12 +74,11 @@ router
     '/accept-invite',
     validate({
       body: Joi.object({
-        token: Joi.string(),
         name: Joi.string().required(),
         password: passwordField.required()
       })
     }),
-    authenticate({ type: 'invite' }, { getToken: (ctx) => ctx.request.body.token }),
+    authenticate({ type: 'invite' }),
     async (ctx) => {
       const { name, password } = ctx.request.body;
       const invite = await Invite.findByIdAndUpdate(ctx.state.jwt.inviteId, {
@@ -133,11 +132,10 @@ router
     '/set-password',
     validate({
       body: Joi.object({
-        token: Joi.string().required(),
         password: passwordField.required()
       })
     }),
-    authenticate({ type: 'password' }, { getToken: (ctx) => ctx.request.body.token }),
+    authenticate({ type: 'password' }),
     async (ctx) => {
       const { password } = ctx.request.body;
       const user = await User.findById(ctx.state.jwt.userId);

--- a/services/web/src/screens/Auth/AcceptInvite/index.js
+++ b/services/web/src/screens/Auth/AcceptInvite/index.js
@@ -34,10 +34,8 @@ export default class AcceptInvite extends React.Component {
       const { data } = await request({
         method: 'POST',
         path: '/1/auth/accept-invite',
-        body: {
-          ...body,
-          token,
-        }
+        token,
+        body,
       });
       await this.context.setToken(data.token);
       this.props.history.push('/');

--- a/services/web/src/screens/Auth/ResetPassword/index.js
+++ b/services/web/src/screens/Auth/ResetPassword/index.js
@@ -39,9 +39,9 @@ export default class ResetPassword extends React.Component {
       const { data } = await request({
         method: 'POST',
         path: '/1/auth/set-password',
+        token,
         body: {
           password,
-          token,
         }
       });
       await this.context.setToken(data.token);


### PR DESCRIPTION
Had some ideas around authentication which I think should be out of the box for bedrock and added some facilities for this...

## Optional Authentication

Goal should be that we can optionally authenticate users and later in the route chain require them ie:

```
.use(authenticate({ type: 'user', optional: true }))
.use(fetchUser)
.post(
  '/insecure',
  async (ctx) => {
    // ctx.state.authUser may or may not exist
  }
)
.use(authenticate({ type: 'user' }))
.use(fetchUser)
.post(
  '/secure',
  async (ctx) => {
    // ctx.state.authUser will exist or error thrown
  }
)
```

further refactored so that both `authenticate` and `fetchUser` middleware can be chained and will not run multiple times when `jwt` and `authUser` (respectively) exist on `ctx.state`. added tests for this

## Consolidate on `Authorization` header

The `request` helper already takes an optional `token` option to set `Authorization: Bearer` so if we use this instead of passing the token up in the body then we can simplify the authenticate middleware further:

before:
```
const { data } = await request({
  method: 'POST',
  path: '/1/auth/set-password',
  body: {
    token,
    password,
  }
});
```

after:
```
const { data } = await request({
  method: 'POST',
  path: '/1/auth/set-password',
  token,
  body: {
    password,
  }
});
```

means that we can get rid of the `{ setToken: () => {} }` option on the middleware and everything will use that header instead