### PR TITLE
Allow optional access to private fields

### DIFF
--- a/services/api/src/lib/utils/__tests__/schema.test.js
+++ b/services/api/src/lib/utils/__tests__/schema.test.js
@@ -1,6 +1,6 @@
 const { createSchema } = require('../schema');
 const mongoose = require('mongoose');
-const { setupDb, teardownDb } = require('../../../test-helpers');
+const { setupDb, teardownDb } = require('../../test-helpers');
 
 beforeAll(async () => {
   await setupDb();
@@ -105,6 +105,52 @@ describe('createSchema', () => {
       expect(data.tags).toBeUndefined();
     });
 
+    it('should serialize identically with toObject', () => {
+      const User = createModel(createSchema({
+        secret: { type: String, access: 'private' },
+      }));
+      const user = new User({
+        secret: 'foo',
+      });
+      const data = user.toObject();
+      expect(data.id).toBe(user.id);
+      expect(data._id).toBeUndefined();
+      expect(data.__v).toBeUndefined();
+      expect(data.secret).toBeUndefined();
+    });
+
+    it('should allow access to private fields with options on toJSON', () => {
+      const User = createModel(createSchema({
+        secret: { type: String, access: 'private' },
+      }));
+      const user = new User({
+        secret: 'foo',
+      });
+      const data = user.toJSON({
+        private: true,
+      });
+      expect(data.id).toBe(user.id);
+      expect(data._id).toBeUndefined();
+      expect(data.__v).toBeUndefined();
+      expect(data.secret).toBe('foo');
+    });
+
+    it('should allow access to private fields with options on toObject', () => {
+      const User = createModel(createSchema({
+        secret: { type: String, access: 'private' },
+      }));
+      const user = new User({
+        secret: 'foo',
+      });
+      const data = user.toObject({
+        private: true,
+      });
+      expect(data.id).toBe(user.id);
+      expect(data._id).toBeUndefined();
+      expect(data.__v).toBeUndefined();
+      expect(data.secret).toBe('foo');
+    });
+
   });
 
   describe('autopopulate', () => {
@@ -143,5 +189,76 @@ describe('createSchema', () => {
       expect(data.user.password).toBeUndefined();
     });
 
+    it('should not allow access to private autopoulated fields by default', async () => {
+      const User = createModel(createSchema({
+        secret: { type: String, access: 'private' },
+      }));
+
+      const shopSchema = createSchema({
+        user: {
+          ref: User.modelName,
+          type: mongoose.Schema.Types.ObjectId,
+          autopopulate: true,
+        }
+      });
+
+      shopSchema.plugin(require('mongoose-autopopulate'));
+      const Shop = createModel(shopSchema);
+
+      const user = new User({
+        secret: 'foo'
+      });
+      await user.save();
+
+      let shop = new Shop();
+      shop.user = user;
+      await shop.save();
+
+      shop = await Shop.findById(shop.id);
+
+      const data = shop.toObject();
+
+      expect(data.user.id).toBe(user.id);
+      expect(data.user._id).toBeUndefined();
+      expect(data.user.__v).toBeUndefined();
+      expect(data.user.secret).toBeUndefined();
+    });
+
+    it('should allow access to private autopoulated fields with options', async () => {
+      const User = createModel(createSchema({
+        secret: { type: String, access: 'private' },
+      }));
+
+      const shopSchema = createSchema({
+        user: {
+          ref: User.modelName,
+          type: mongoose.Schema.Types.ObjectId,
+          autopopulate: true,
+        }
+      });
+
+      shopSchema.plugin(require('mongoose-autopopulate'));
+      const Shop = createModel(shopSchema);
+
+      const user = new User({
+        secret: 'foo'
+      });
+      await user.save();
+
+      let shop = new Shop();
+      shop.user = user;
+      await shop.save();
+
+      shop = await Shop.findById(shop.id);
+
+      const data = shop.toObject({
+        private: true
+      });
+
+      expect(data.user.id).toBe(user.id);
+      expect(data.user._id).toBeUndefined();
+      expect(data.user.__v).toBeUndefined();
+      expect(data.user.secret).toBe('foo');
+    });
   });
 });

--- a/services/api/src/lib/utils/__tests__/schema.test.js
+++ b/services/api/src/lib/utils/__tests__/schema.test.js
@@ -1,6 +1,6 @@
 const { createSchema } = require('../schema');
 const mongoose = require('mongoose');
-const { setupDb, teardownDb } = require('../../test-helpers');
+const { setupDb, teardownDb } = require('../../../test-helpers');
 
 beforeAll(async () => {
   await setupDb();

--- a/services/api/src/middlewares/__tests__/authenticate.js
+++ b/services/api/src/middlewares/__tests__/authenticate.js
@@ -156,6 +156,14 @@ describe('fetchUser', () => {
     });
   });
 
+  it('it should not fail without jwt token', async () => {
+    const user = await createUser();
+    const ctx = context();
+    await fetchUser(ctx, () => {
+      expect(ctx.state.authUser).toBeUndefined();
+    });
+  });
+
   it('it should not fetch the user twice when called with the same context', async () => {
     const user = await createUser();
     const ctx = context();

--- a/services/api/src/middlewares/authenticate.js
+++ b/services/api/src/middlewares/authenticate.js
@@ -55,7 +55,7 @@ exports.authenticate = ({ type, optional = false } = {}) => {
 };
 
 exports.fetchUser = async (ctx, next) => {
-  if (!ctx.state.authUser) {
+  if (!ctx.state.authUser && ctx.state.jwt) {
     ctx.state.authUser = await User.findById(ctx.state.jwt.userId);
     if (!ctx.state.authUser) ctx.throw(400, 'user associated to token could not not be found');
   }


### PR DESCRIPTION
I previously added the concept of "private" fields on bedrock models. These would be stripped out when serializing to avoid exposing things like hashed password etc.

However there are cases when you want to expose private fields to admin etc. This is the underpinning to that.

The idea is to be used like this:

```js
const shop = await Shop.findById(id);
ctx.body = {
  data: shop.toObject({
    private: authUser && authUser.isAdmin(),
  });
};
```

Combined with the new optional authentication middleware the above will expose any private field on the shop model for an admin user and no one else (unauthenticated or other type of user).

Next step would be to have different user-defined levels of access other than private. It could also theoretically take user roles for access (ie. something like `{ access: 'admin' }` vs `{ access: 'none' }`) but I don't want to go as far as tying roles into our models just yet.

Added tests to ensure private fields are properly exposed and hidden as expected for regular fields as well as autopopulated.

Additionally added tests ensuring that `toObject` and `toJSON` (which is called internally by `JSON.stringify`) operate the same as they should be synonymous.
