### PR TITLE
Underpinning for minimal common screen behavior

### DIFF
--- a/services/web/package.json
+++ b/services/web/package.json
@@ -54,6 +54,7 @@
     "react-day-picker": "^7.4.8",
     "react-dom": "^16.13.1",
     "react-dropzone": "^11.0.1",
+    "react-helmet-async": "^1.0.6",
     "react-hot-loader": "^4.12.21",
     "react-markdown": "^4.3.1",
     "react-router": "^5.1.2",

--- a/services/web/src/helpers/index.js
+++ b/services/web/src/helpers/index.js
@@ -1,0 +1,1 @@
+export { default as screen } from './screen';

--- a/services/web/src/helpers/screen.js
+++ b/services/web/src/helpers/screen.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { startCase } from 'lodash';
+import { Helmet } from 'react-helmet-async';
+import { APP_NAME } from 'utils/env';
+
+export default function(Component) {
+
+  return class Screen extends React.PureComponent {
+
+    render() {
+      return (
+        <React.Fragment>
+          <Helmet>
+            {this.renderTitle()}
+            {this.renderCanonical()}
+          </Helmet>
+          <Component {...this.props} />
+        </React.Fragment>
+      );
+    }
+
+    renderTitle() {
+      const parts = [];
+      parts.push(Component.title || startCase(Component.name));
+      parts.push(APP_NAME);
+      return <title>{parts.join(' | ')}</title>;
+    }
+
+    renderCanonical() {
+      return <link rel="canonical" href={location.href} />;
+    }
+
+  };
+}

--- a/services/web/src/index.js
+++ b/services/web/src/index.js
@@ -5,6 +5,7 @@ import 'react-hot-loader';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
+import { HelmetProvider } from 'react-helmet-async';
 import { SENTRY_DSN } from 'utils/env';
 import { SessionProvider } from 'stores';
 import App from './App';
@@ -16,7 +17,9 @@ if (SENTRY_DSN && window.Sentry) {
 const Wrapper = () => (
   <BrowserRouter>
     <SessionProvider>
-      <App />
+      <HelmetProvider>
+        <App />
+      </HelmetProvider>
     </SessionProvider>
   </BrowserRouter>
 );

--- a/services/web/src/screens/Auth/AcceptInvite/index.js
+++ b/services/web/src/screens/Auth/AcceptInvite/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Segment, Grid } from 'semantic-ui-react';
 import { request } from 'utils/api';
 import { withSession } from 'stores';
+import { screen } from 'helpers';
 import PageCenter from 'components/PageCenter';
 import LogoTitle from 'components/LogoTitle';
 
@@ -9,6 +10,7 @@ import Form from './Form';
 import { Link } from 'react-router-dom';
 import { getToken, parseToken } from 'utils/token';
 
+@screen
 @withSession
 export default class AcceptInvite extends React.Component {
 

--- a/services/web/src/screens/Auth/ForgotPassword/index.js
+++ b/services/web/src/screens/Auth/ForgotPassword/index.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import { Segment, Message, Grid } from 'semantic-ui-react';
 import { request } from 'utils/api';
+import { screen } from 'helpers';
 import PageCenter from 'components/PageCenter';
 import LogoTitle from 'components/LogoTitle';
 import Form from './Form';
 
 import { Link } from 'react-router-dom';
 
+@screen
 export default class ForgotPassword extends React.Component {
   state = {
     success: false,

--- a/services/web/src/screens/Auth/Login/index.js
+++ b/services/web/src/screens/Auth/Login/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { request } from 'utils/api';
 import { Segment, Grid } from 'semantic-ui-react';
 import { withSession } from 'stores';
+import { screen } from 'helpers';
 
 import PageCenter from 'components/PageCenter';
 import LogoTitle from 'components/LogoTitle';
@@ -9,6 +10,7 @@ import LogoTitle from 'components/LogoTitle';
 import LoginForm from './Form';
 import { Link } from 'react-router-dom';
 
+@screen
 @withSession
 export default class Login extends React.Component {
 

--- a/services/web/src/screens/Auth/ResetPassword/index.js
+++ b/services/web/src/screens/Auth/ResetPassword/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Segment, Message } from 'semantic-ui-react';
 import { withSession } from 'stores';
 import { request } from 'utils/api';
+import { screen } from 'helpers';
 
 import PageCenter from 'components/PageCenter';
 import LogoTitle from 'components/LogoTitle';
@@ -10,6 +11,7 @@ import { Link } from 'react-router-dom';
 
 import { getToken, parseToken } from 'utils/token';
 
+@screen
 @withSession
 export default class ResetPassword extends React.Component {
 

--- a/services/web/src/screens/Auth/Signup/index.js
+++ b/services/web/src/screens/Auth/Signup/index.js
@@ -4,10 +4,12 @@ import PageCenter from 'components/PageCenter';
 import LogoTitle from 'components/LogoTitle';
 import { withSession } from 'stores';
 import { request } from 'utils/api';
+import { screen } from 'helpers';
 
 import Form from './Form';
 import { Link } from 'react-router-dom';
 
+@screen
 @withSession
 export default class Signup extends React.Component {
 

--- a/services/web/src/screens/Dashboard/index.js
+++ b/services/web/src/screens/Dashboard/index.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import AppWrapper from 'components/AppWrapper';
 import { withSession } from 'stores';
+import { screen } from 'helpers';
 
+@screen
 @withSession
 export default class Home extends React.Component {
 

--- a/services/web/src/screens/Docs/index.js
+++ b/services/web/src/screens/Docs/index.js
@@ -11,6 +11,7 @@ import USERS_MD from 'docs/USERS.md';
 import UPLOADS_MD from 'docs/UPLOADS.md';
 import SHOPS_MD from 'docs/SHOPS.md';
 import { request } from '../../utils/api';
+import { screen } from 'helpers';
 
 const pages = [
   {
@@ -48,6 +49,7 @@ function stateForParams(params) {
   };
 }
 
+@screen
 export default class Docs extends React.Component {
   contextRef = createRef();
 
@@ -60,6 +62,7 @@ export default class Docs extends React.Component {
       ...stateForParams(this.props.match.params),
     };
   }
+
   state = {
     loading: true,
     error: null,

--- a/services/web/src/screens/Invites/index.js
+++ b/services/web/src/screens/Invites/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { request } from 'utils/api';
 import { formatDateTime } from 'utils/date';
+import { screen } from 'helpers';
 
 import { SearchProvider } from 'components/data';
 import { Layout } from 'components/Layout';
@@ -16,6 +17,7 @@ import {
   Message,
 } from 'semantic-ui-react';
 
+@screen
 export default class Home extends React.Component {
 
   onDataNeeded = async (params) => {

--- a/services/web/src/screens/Settings/index.js
+++ b/services/web/src/screens/Settings/index.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import { withSession } from 'stores';
+import { screen } from 'helpers';
 import AppWrapper from 'components/AppWrapper';
 
+@screen
 @withSession
-export default class Home extends React.Component {
+export default class Settings extends React.Component {
   render() {
     const { user } = this.context;
     return (

--- a/services/web/src/screens/Shop/Overview.js
+++ b/services/web/src/screens/Shop/Overview.js
@@ -2,7 +2,9 @@ import React from 'react';
 import { Header, Table, Image } from 'semantic-ui-react';
 import { urlForUpload } from 'utils/uploads';
 import { formatDateTime } from 'utils/date';
+import { screen } from 'helpers';
 
+@screen
 export default class ShopOverview extends React.Component {
   render() {
     const { shop } = this.props;

--- a/services/web/src/screens/Shop/Products.js
+++ b/services/web/src/screens/Shop/Products.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Container, Table, Message, Image, Button, Header } from 'semantic-ui-react';
 import { formatDateTime } from 'utils/date';
 import { request } from 'utils/api';
+import { screen } from 'helpers';
 import { urlForUpload } from 'utils/uploads';
 
 import { SearchProvider } from 'components/data';
@@ -10,6 +11,7 @@ import { Confirm } from 'components/Semantic';
 import HelpTip from 'components/HelpTip';
 import EditProduct from 'components/modals/EditProduct';
 
+@screen
 export default class ShopProducts extends React.Component {
 
   onDataNeeded = async (params) => {

--- a/services/web/src/screens/Shops/index.js
+++ b/services/web/src/screens/Shops/index.js
@@ -4,6 +4,7 @@ import { Container, Header, Table, Button, Message } from 'semantic-ui-react';
 import { getData } from 'country-list';
 import { formatDateTime } from 'utils/date';
 import { request } from 'utils/api';
+import { screen } from 'helpers';
 
 import AppWrapper from 'components/AppWrapper';
 import { Layout } from 'components/Layout';
@@ -20,6 +21,7 @@ const countries = getData().map(({ code, name }) => ({
   key: code,
 }));
 
+@screen
 export default class Shops extends React.Component {
   onDataNeeded = async (params) => {
     return await request({

--- a/services/web/src/screens/Users/index.js
+++ b/services/web/src/screens/Users/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { formatDateTime } from 'utils/date';
 import { request } from 'utils/api';
 import { Layout } from 'components/Layout';
+import { screen } from 'helpers';
 
 import { Confirm } from 'components/Semantic';
 import AppWrapper from 'components/AppWrapper';
@@ -18,6 +19,7 @@ import {
   Button,
 } from 'semantic-ui-react';
 
+@screen
 export default class Users extends React.Component {
 
   onDataNeeded = async (params) => {

--- a/services/web/yarn.lock
+++ b/services/web/yarn.lock
@@ -8873,6 +8873,22 @@ react-dropzone@^11.0.1:
     file-selector "^0.1.12"
     prop-types "^15.7.2"
 
+react-fast-compare@^3.0.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
+react-helmet-async@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-1.0.6.tgz#11c15c74e79b3f66670c73779bef3e0e352b1d4e"
+  integrity sha512-t+bhAI4NgxfEv8ez4r77cLfR4O4Z55E/FH2DT+uiE4U7yfWgAk7OAOi7IxHxuYEVLI26bqjZvlVCkpC5/5AoNA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    invariant "^2.2.4"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.0.1"
+    shallowequal "^1.1.0"
+
 react-hot-loader@^4.12.21:
   version "4.12.21"
   resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.12.21.tgz#332e830801fb33024b5a147d6b13417f491eb975"


### PR DESCRIPTION
In every project I've used bedrock in so far I've needed a number of behaviors that are specific to screens that don't apply to components. This includes:

- Applying meta tags for SEO
- Capturing analytics pageviews
- Scrolling to the top of the screen on page change
- Firing a custom "routeDidChange" event for when a route changes, for example refetching data when `?q=` changes. This is distinct behavior from `componentDidUpdate` as the state is coming directly from the URL.

This decorator is the underpinning for that. It has only what I consider "base" functionality needed for all sites, which is rendering a canonical meta tag and building a pretty title based on `APP_NAME`. The underlying facility is the point here but notably:

```jsx
@screen
export default Home extends React.Component {}
// Page title will be "Home | My App"
```

```jsx
@screen
export default Home extends React.Component {
   static title = 'My Title';
}
// Page title will be "My Title | My App"
```

```jsx
@screen
export default Home extends React.Component {
   static get title() {
      // dynamically get the title
      return 'Custom Title';
   }
}
// Page title will be "Custom Title | My App"
```