### PR TITLE
Routing refactors

### DIFF
--- a/services/web/src/components/routes/AuthSwitch.js
+++ b/services/web/src/components/routes/AuthSwitch.js
@@ -1,39 +1,46 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Route, Link } from 'react-router-dom';
-import { Message } from 'semantic-ui-react';
+import { Loader, Message } from 'semantic-ui-react';
+import { Layout } from '../Layout';
 import { withSession } from 'stores';
-import PageCenter from '../PageCenter';
-import PageLoader from '../PageLoader';
 
 @withSession
 export default class AuthSwitch extends React.Component {
 
+  hasAccess() {
+    const { admin, roles } = this.props;
+    const { user, isAdmin, hasRoles } = this.context;
+    if (!user) {
+      return false;
+    } else if (admin) {
+      return isAdmin();
+    } else if (roles.length) {
+      return hasRoles(roles);
+    }
+    return true;
+  }
+
   render() {
-    const { user, loading, error } = this.context;
+    const { loading, error } = this.context;
     const { loggedIn: LoggedInComponent, loggedOut: LoggedOutComponent, ...rest } = this.props;
-    if (error || loading) {
+    if (loading) {
+      return <Loader active>Loading</Loader>;
+    } else if (error) {
       return (
-        <PageCenter>
-          {error && (
-            <React.Fragment>
-              <Message
-                error
-                header="Something went wrong"
-                content={error.message}
-              />
-              <Link to="/logout">Logout</Link>
-            </React.Fragment>
-          )}
-          {loading && <PageLoader />}
-        </PageCenter>
+        <Layout style={{ height: '100%' }} center>
+          <Layout.Group>
+            <Message error header="Something went wrong" content={error.message} />
+            <Link to="/logout">Logout</Link>
+          </Layout.Group>
+        </Layout>
       );
     }
     return (
       <Route
         {...rest}
         render={(props) => {
-          return user ? <LoggedInComponent {...props} /> : <LoggedOutComponent {...props} />;
+          return this.hasAccess() ? <LoggedInComponent {...props} /> : <LoggedOutComponent {...props} />;
         }}
       />
     );
@@ -41,7 +48,14 @@ export default class AuthSwitch extends React.Component {
 }
 
 AuthSwitch.propTypes = {
+  admin: PropTypes.bool,
+  roles: PropTypes.array,
   loggedIn: PropTypes.elementType.isRequired,
   loggedOut: PropTypes.elementType.isRequired,
   ...Route.propTypes,
+};
+
+AuthSwitch.defaultProps = {
+  admin: false,
+  roles: [],
 };

--- a/services/web/src/components/routes/Protected.js
+++ b/services/web/src/components/routes/Protected.js
@@ -7,61 +7,27 @@ import AuthSwitch from './AuthSwitch';
 @withSession
 export default class Protected extends React.Component {
 
-  hasAccess() {
-    const { user, hasRole } = this.context;
-    if (!user) {
-      return false;
-    }
-    return this.getRoles().every((role) => {
-      return hasRole(role);
-    });
-  }
-
-  getRoles() {
-    const { admin, roles } = this.props;
-    return admin ? ['admin'] : roles;
-  }
-
   render() {
-    const { exact, path } = this.props;
+    const { allowed: AllowedComponent, denied: DeniedComponent, ...rest } = this.props;
     return (
       <AuthSwitch
-        exact={exact}
-        path={path}
-        loggedOut={(props) => this.renderAccessDenied(props)}
-        loggedIn={(props) => this.renderLoggedIn(props)}
+        loggedIn={AllowedComponent}
+        loggedOut={DeniedComponent}
+        {...rest}
       />
     );
   }
 
-  renderLoggedIn(props) {
-    const { allowed: AllowedComponent } = this.props;
-    if (this.hasAccess()) {
-      return <AllowedComponent {...props} />;
-    } else {
-      return this.renderAccessDenied(props);
-    }
-  }
-
-  renderAccessDenied(props) {
-    const { denied: DeniedComponent } = this.props;
-    if (DeniedComponent) {
-      return <DeniedComponent {...props} />;
-    } else {
-      return <Redirect to="/" />;
-    }
-  }
 }
 
 Protected.propTypes = {
   admin: PropTypes.bool,
   roles: PropTypes.array,
   allowed: PropTypes.elementType.isRequired,
-  denied: PropTypes.elementType,
+  denied: PropTypes.oneOfType([PropTypes.elementType, PropTypes.string]),
   ...Route.propTypes,
 };
 
 Protected.defaultProps = {
-  admin: false,
-  roles: [],
+  denied: () => <Redirect to="/" />,
 };

--- a/services/web/src/stores/session.js
+++ b/services/web/src/stores/session.js
@@ -21,12 +21,14 @@ export class SessionProvider extends React.PureComponent {
   }
 
   isAdmin = () => {
-    return this.hasRole('admin');
+    return this.hasRoles(['admin']);
   };
 
-  hasRole = (role) => {
+  hasRoles = (roles = []) => {
     const { user } = this.state;
-    return user?.roles.includes(role);
+    return roles.some((role) => {
+      return user?.roles.includes(role);
+    });
   };
 
   setToken = async (token) => {
@@ -130,8 +132,8 @@ export class SessionProvider extends React.PureComponent {
           clearStored: this.clearStored,
           updateUser: this.updateUser,
           loadUser: this.loadUser,
+          hasRoles: this.hasRoles,
           isAdmin: this.isAdmin,
-          hasRole: this.hasRole,
         }}>
         {this.props.children}
       </SessionContext.Provider>


### PR DESCRIPTION
1. Simplified routing by moving access checks into `AuthSwitch`. This means you can use `admin` or `roles` props on that too and it will take them into account:

Default logged in users only:
```jsx
<AuthSwitch path="/" loggedIn={Dashboard} loggedOut={Login} exact />
```

Allows admins only:
```jsx
<AuthSwitch path="/" loggedIn={Dashboard} loggedOut={Login} exact admin />
```

Allows specific roles:
```jsx
<AuthSwitch path="/" loggedIn={Dashboard} loggedOut={Login} exact roles={['editor']} />
```

...actually there's not much difference between `AuthSwitch` and `Protected` now but I want to leave them both as depending on what you're doing it reads better. Basically only difference is protected will redirect by default to`/`, where AuthSwitch will throw if you don't give a `loggedOut` prop.