### PR TITLE
Search Utils

### DIFF
--- a/services/api/package.json
+++ b/services/api/package.json
@@ -26,6 +26,7 @@
     "@koa/router": "^9.3.1",
     "@sentry/node": "^5.20.1",
     "bcrypt": "^5.0.0",
+    "fast-csv": "^4.3.2",
     "jsonwebtoken": "^8.5.1",
     "koa": "^2.13.0",
     "koa-body": "^4.2.0",

--- a/services/api/src/lib/utils/search.js
+++ b/services/api/src/lib/utils/search.js
@@ -159,7 +159,7 @@ exports.commonSearch = function ({
 }) {
   return [
     validate({
-      body: {
+      body: Joi.object({
         ...exports.commonSearchValidation({
           defaultExportFilename,
           defaultSortField,
@@ -167,7 +167,7 @@ exports.commonSearch = function ({
           exactStringMatchFields,
         }),
         ...(validateBody || {}),
-      },
+      }),
     }),
     async (ctx) => {
       const baseQuery = exports.commonSearchCreateQuery(ctx.request.body, {
@@ -184,7 +184,7 @@ exports.commonSearch = function ({
       }
 
       ctx.body = {
-        data: data.map((i) => i.toResource()),
+        data,
         meta,
       };
     },

--- a/services/api/src/lib/utils/search.js
+++ b/services/api/src/lib/utils/search.js
@@ -1,0 +1,192 @@
+const ObjectId = require('mongoose').Types.ObjectId;
+const Joi = require('@hapi/joi');
+const PassThrough = require('stream').PassThrough;
+const csv = require('fast-csv');
+const validate = require('../../middlewares/validate');
+
+exports.escapeRegExp = (string) => {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+};
+
+const numberFormatter = Intl.NumberFormat('en');
+
+exports.flatten = function flatten(obj, opt_out, opt_paths) {
+  const out = opt_out || {};
+  const paths = opt_paths || [];
+  return Object.getOwnPropertyNames(obj).reduce(function (out, key) {
+    paths.push(key);
+
+    if (typeof obj[key] === 'number') {
+      out[paths.join('.')] = numberFormatter.format(obj[key]);
+    } else if (ObjectId.isValid(obj[key])) {
+      out[paths.join('.')] = obj[key].toString();
+    } else if (obj[key] instanceof Date) {
+      out[paths.join('.')] = obj[key].toISOString();
+    } else if (typeof obj[key] === 'object' && !Array.isArray(obj[key]) && !!obj[key]) {
+      flatten(obj[key], out, paths);
+    } else {
+      out[paths.join('.')] = obj[key];
+    }
+    paths.pop();
+    return out;
+  }, out);
+};
+
+exports.commonSearchValidation = function ({
+  defaultExportFilename = 'export.csv',
+  defaultSortField = undefined,
+  defaultSortOrder = 'desc',
+  defaultDateField = 'createdAt',
+  exactStringMatchFields = [],
+} = {}) {
+  if (!defaultSortField) {
+    defaultSortField = defaultDateField;
+  }
+  const validation = {
+    filename: Joi.string().default(defaultExportFilename),
+    from: Joi.date(),
+    to: Joi.date(),
+    format: Joi.string().allow('json', 'csv').default('json'),
+    skip: Joi.number().default(0),
+    sort: Joi.object({
+      field: Joi.string().required(),
+      order: Joi.string().allow('asc', 'desc').required(),
+    }).default({
+      field: defaultSortField,
+      order: defaultSortOrder,
+    }),
+    id: Joi.string(),
+    ids: Joi.array().items(Joi.string()),
+    searchId: Joi.string(),
+    limit: Joi.number().positive().default(50),
+  };
+  exactStringMatchFields.forEach((key) => {
+    validation[key] = Joi.string();
+  });
+  return validation;
+};
+
+exports.commonSearchCreateQuery = function (body, options = {}) {
+  const { from, to, searchId, id, ids = [] } = body;
+  const query = { deletedAt: { $exists: false } };
+  if (id) {
+    query._id = id;
+  }
+  if (ids.length) {
+    query._id = { $in: ids };
+  }
+  if (from || to) {
+    query[options.defaultDateField || 'createdAt'] = { $gte: from, $lt: to };
+  }
+  if (searchId && options.searchFields) {
+    query.$or = options.searchFields.map((field) => {
+      return {
+        [field]: {
+          $regex: searchId,
+          $options: 'i',
+        },
+      };
+    });
+    if (ObjectId.isValid(searchId)) {
+      query.$or.push({
+        _id: searchId,
+      });
+    }
+  }
+  if (options.exactStringMatchFields) {
+    options.exactStringMatchFields.forEach((key) => {
+      if (body[key]) {
+        query[key] = body[key];
+      }
+    });
+  }
+  return query;
+};
+
+exports.commonSearchFind = async function (body, model, query, populateFields) {
+  const { sort, skip, limit } = body;
+
+  let find = model
+    .find(query)
+    .sort({ [sort.field]: sort.order === 'desc' ? -1 : 1 })
+    .skip(skip)
+    .limit(limit);
+  populateFields.forEach((field) => {
+    find = find.populate(field);
+  });
+  const data = await find.exec();
+
+  const total = await model.countDocuments(query);
+  return {
+    data,
+    meta: {
+      total,
+      skip,
+      limit,
+    },
+  };
+};
+
+exports.commonSearchExport = function (ctx, data) {
+  const { format, filename } = ctx.request.body;
+  if (format === 'csv') {
+    const csvStream = csv.format({ headers: true, objectMode: true, delimiter: ';' });
+
+    ctx.body = csvStream.pipe(PassThrough());
+
+    data.forEach((item) => {
+      csvStream.write(exports.flatten(item.toResource()));
+    });
+    ctx.set('Content-Disposition', `attachment; filename=${filename}`);
+    ctx.set('Content-Type', 'text/csv');
+    csvStream.end();
+    return true;
+  }
+  return false;
+};
+
+exports.commonSearch = function ({
+  model,
+  validateBody,
+  defaultExportFilename,
+  defaultSortField,
+  defaultSortOrder,
+  defaultDateField,
+  createQuery,
+  searchFields,
+  populateFields,
+  exactStringMatchFields,
+}) {
+  return [
+    validate({
+      body: {
+        ...exports.commonSearchValidation({
+          defaultExportFilename,
+          defaultSortField,
+          defaultSortOrder,
+          exactStringMatchFields,
+        }),
+        ...(validateBody || {}),
+      },
+    }),
+    async (ctx) => {
+      const baseQuery = exports.commonSearchCreateQuery(ctx.request.body, {
+        searchFields,
+        defaultDateField,
+        exactStringMatchFields,
+      });
+
+      const query = await createQuery(ctx, baseQuery);
+      const { data, meta } = await exports.commonSearchFind(ctx.request.body, model, query, populateFields || []);
+
+      if (exports.commonSearchExport(ctx, data)) {
+        return;
+      }
+
+      ctx.body = {
+        data: data.map((i) => i.toResource()),
+        meta,
+      };
+    },
+  ];
+};

--- a/services/api/yarn.lock
+++ b/services/api/yarn.lock
@@ -283,6 +283,29 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@fast-csv/format@4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@fast-csv/format/-/format-4.3.1.tgz#e550731487002e0d1bac13422dd8506cdfd60f50"
+  integrity sha512-Ap6KSt0iJlzrivZU4grQzDGGOQ+vN5kvUeOHLF1BE7nWri1auiodgS3SCffvLe1Zvu79tACe1tw3dyBADk1NsA==
+  dependencies:
+    lodash.escaperegexp "^4.1.2"
+    lodash.isboolean "^3.0.3"
+    lodash.isequal "^4.5.0"
+    lodash.isfunction "^3.0.9"
+    lodash.isnil "^4.0.0"
+
+"@fast-csv/parse@4.3.2":
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/@fast-csv/parse/-/parse-4.3.2.tgz#55caaee17431b9ba655c0aef7b453305e7b5039d"
+  integrity sha512-smFKL1E00zy6SB+MIRL4kJq4ba4Is9mHEf+1kdMH7iLInrKszADyJFGicoRfiFTtAvm+661LJMWjyQHrmx6WeA==
+  dependencies:
+    lodash.escaperegexp "^4.1.2"
+    lodash.groupby "^4.6.0"
+    lodash.isfunction "^3.0.9"
+    lodash.isnil "^4.0.0"
+    lodash.isundefined "^3.0.1"
+    lodash.uniq "^4.5.0"
+
 "@google-cloud/common@^3.0.0":
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/@google-cloud/common/-/common-3.3.2.tgz#595ce85ebbcaa8b38519336bf6747e32e7706df7"
@@ -1241,6 +1264,11 @@
   version "13.13.15"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.15.tgz#fe1cc3aa465a3ea6858b793fd380b66c39919766"
   integrity sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw==
+
+"@types/node@^14.0.1":
+  version "14.6.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.4.tgz#a145cc0bb14ef9c4777361b7bbafa5cf8e3acb5a"
+  integrity sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==
 
 "@types/node@^6.14.4", "@types/node@^6.14.7":
   version "6.14.10"
@@ -3381,6 +3409,15 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
+fast-csv@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/fast-csv/-/fast-csv-4.3.2.tgz#855e28d034310f8aae10f959bfea0a60d34540fb"
+  integrity sha512-tmvVMsliprsl7P1z++XuhfGZPTz/h2sTLhs5PYVhtOSsu7t0T2q1TdWq/CORQsD9Cc2oPiTchpf7gACLXArNYQ==
+  dependencies:
+    "@fast-csv/format" "4.3.1"
+    "@fast-csv/parse" "4.3.2"
+    "@types/node" "^14.0.1"
+
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -5341,7 +5378,7 @@ lodash.constant@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash.constant/-/lodash.constant-3.0.0.tgz#bfe05cce7e515b3128925d6362138420bd624910"
   integrity sha1-v+Bczn5RWzEokl1jYhOEIL1iSRA=
 
-lodash.escaperegexp@^4.1.0:
+lodash.escaperegexp@^4.1.0, lodash.escaperegexp@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
   integrity sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=
@@ -5370,6 +5407,11 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.groupby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.groupby/-/lodash.groupby-4.6.0.tgz#0b08a1dcf68397c397855c3239783832df7403d1"
+  integrity sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E=
 
 lodash.has@^4.5.2:
   version "4.5.2"
@@ -5410,6 +5452,11 @@ lodash.isinteger@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
   integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
+
+lodash.isnil@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/lodash.isnil/-/lodash.isnil-4.0.0.tgz#49e28cd559013458c814c5479d3c663a21bfaa6c"
+  integrity sha1-SeKM1VkBNFjIFMVHnTxmOiG/qmw=
 
 lodash.isnumber@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
This is a set of utility functions to make search easier:

- Support for CSV exports by default
- Skinnier controllers in API routes
- MongoDB regexp escaping functions
- Search across multiple fields

One big issue here is that we're adding a new abstraction layer. Should we only have this as a facility and not enable this by default? Thoughts welcome