### PR TITLE
Allow deletion of ObjectId references method in user.assign

### DIFF
--- a/services/api/src/lib/utils/__tests__/schema.test.js
+++ b/services/api/src/lib/utils/__tests__/schema.test.js
@@ -202,7 +202,7 @@ describe('createSchema', () => {
       expect(user.password).not.toBe('fake password');
     });
 
-    it('should delete null values for reference fields', async () => {
+    it('should delete falsy values for reference fields', async () => {
       const User = createModel(createSchema({
         password: { type: String, access: 'private' },
       }));

--- a/services/api/src/lib/utils/__tests__/schema.test.js
+++ b/services/api/src/lib/utils/__tests__/schema.test.js
@@ -62,14 +62,14 @@ describe('createSchema', () => {
     it('should expose id', () => {
       const User = createModel(createSchema());
       const user = new User();
-      const data = JSON.parse(JSON.stringify(user));
+      const data = user.toObject();
       expect(data.id).toBe(user.id);
     });
 
     it('should not expose _id or __v', () => {
       const User = createModel(createSchema());
       const user = new User();
-      const data = JSON.parse(JSON.stringify(user));
+      const data = user.toObject();
       expect(data._id).toBeUndefined();
       expect(data.__v).toBeUndefined();
     });
@@ -86,7 +86,7 @@ describe('createSchema', () => {
       expect(user._private).toBe('private');
       expect(user.password).toBe('fake password');
 
-      const data = JSON.parse(JSON.stringify(user));
+      const data = user.toObject();
 
       expect(data._private).toBeUndefined();
       expect(data.password).toBeUndefined();
@@ -101,7 +101,7 @@ describe('createSchema', () => {
 
       expect(user.tags).toBeInstanceOf(Array);
 
-      const data = JSON.parse(JSON.stringify(user));
+      const data = user.toObject();
       expect(data.tags).toBeUndefined();
     });
 

--- a/services/api/src/lib/utils/schema.js
+++ b/services/api/src/lib/utils/schema.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 const { omitBy } = require('lodash');
+const { ObjectId } = mongoose.Schema.Types;
 
 const RESERVED_FIELDS = ['id', 'createdAt', 'updatedAt', 'deletedAt'];
 
@@ -36,9 +37,15 @@ exports.createSchema = (definition, options = {}) => {
     }
   );
   schema.methods.assign = function assign(fields) {
-    Object.assign(this, omitBy(fields, (value, key) => {
+    fields = omitBy(fields, (value, key) => {
       return isDisallowedField(this, key) || RESERVED_FIELDS.includes(key);
-    }));
+    })
+    for (let [key, value] of Object.entries(fields)) {
+      if (!value && isReferenceField(this, key)) {
+        value = undefined;
+      }
+      this[key] = value;
+    }
   };
   schema.methods.delete = function() {
     this.deletedAt = new Date();
@@ -47,13 +54,20 @@ exports.createSchema = (definition, options = {}) => {
   return schema;
 };
 
+function isReferenceField(doc, key) {
+  const field = getField(doc, key);
+  return field.type === ObjectId;
+}
+
 function isDisallowedField(doc, key, allowPrivate = false) {
-  let field = doc.schema.obj[key];
-  if (Array.isArray(field)) {
-    field = field[0];
-  }
+  const field = getField(doc, key);
   if (field && field.access === 'private') {
     return !allowPrivate;
   }
   return false;
+}
+
+function getField(doc, key) {
+  const field = doc.schema.obj[key];
+  return Array.isArray(field) ? field[0] : field;
 }


### PR DESCRIPTION
## Reason

In mongoose ObjectId references are unset by assigning to `undefined`:

```js
user.address = undefined;
await user.save();
```

Note that because of some mongoose metaprogramming magic `delete user.address` doesn't work here.
Setting `null` here has a different meaning, however and won't unset the field but instead sets it to `null`.

In patch updates, it's common to need to unset a field, however `undefined` is not a valid JSON primitive, so this can't be easily done. This PR allows an empty string to unset reference fields within the `schema.assign` method so that you can do this:

```js
 .patch(
    '/:userId',
    validate({
      body: Joi.object({
        address: Joi.string().allow(''),
      }),
    }),
    async (ctx) => {
      const { user } = ctx.state;
      user.assign(ctx.request.body);
      await user.save();
      ctx.body = {
        data: user,
      };
    }
  )
```

Note that whether or not unsetting is allowed is still up to the route validation, `assign` is (still) designed to be a lower level method that assumes input is validated.