### PR TITLE
loading sentry via npm, thats the recommended way for the moment

### DIFF
--- a/services/web/env.js
+++ b/services/web/env.js
@@ -13,6 +13,7 @@ const all = {
 module.exports = {
   ...all,
   publicEnv: pick(all, [
+    'ENV_NAME',
     'DEV',
     'PROD',
     'STAGING',

--- a/services/web/package.json
+++ b/services/web/package.json
@@ -22,6 +22,7 @@
     "@babel/preset-react": "^7.9.4",
     "@bedrockio/config": "^2.0.3",
     "@hot-loader/react-dom": "^16.13.0",
+    "@sentry/browser": "^6.0.1",
     "autoprefixer": "^9.7.6",
     "babel-loader": "^8.1.0",
     "babel-plugin-lodash": "^3.3.4",

--- a/services/web/src/index.html
+++ b/services/web/src/index.html
@@ -3,18 +3,19 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="Content-Language" content="en" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0"
+    />
     <title><%= APP_NAME %></title>
-    <script src="https://browser.sentry-cdn.com/4.6.4/bundle.min.js" crossorigin="anonymous"></script>
-    <% if (GTM_CONTAINER_ID) { %>
-      <%= require('utils/analytics/head.html') %>
-    <% } %>
+
+    <% if (GTM_CONTAINER_ID) { %> <%= require('utils/analytics/head.html') %> <%
+    } %>
     <!--env:conf-->
   </head>
   <body>
     <div id="root"></div>
-    <% if (GTM_CONTAINER_ID) { %>
-      <%= require('utils/analytics/body.html') %>
-    <% } %>
+    <% if (GTM_CONTAINER_ID) { %> <%= require('utils/analytics/body.html') %> <%
+    } %>
   </body>
 </html>

--- a/services/web/src/index.js
+++ b/services/web/src/index.js
@@ -1,21 +1,14 @@
 // react-hot-loader needs to be imported
 // before react and react-dom
 import 'react-hot-loader';
-import Sentry from '@sentry/browser';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 import { HelmetProvider } from 'react-helmet-async';
-import { SENTRY_DSN } from 'utils/env';
 import { SessionProvider } from 'stores';
 import App from './App';
-
-if (SENTRY_DSN) {
-  Sentry.init({
-    dsn: SENTRY_DSN,
-    enable: !['development', 'test'].includes(ENV_NAME),
-  });
-}
+import 'utils/sentry';
 
 const Wrapper = () => (
   <BrowserRouter>

--- a/services/web/src/index.js
+++ b/services/web/src/index.js
@@ -1,7 +1,7 @@
 // react-hot-loader needs to be imported
 // before react and react-dom
 import 'react-hot-loader';
-
+import Sentry from '@sentry/browser';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
@@ -10,8 +10,11 @@ import { SENTRY_DSN } from 'utils/env';
 import { SessionProvider } from 'stores';
 import App from './App';
 
-if (SENTRY_DSN && window.Sentry) {
-  window.Sentry.init({ dsn: SENTRY_DSN });
+if (SENTRY_DSN) {
+  Sentry.init({
+    dsn: SENTRY_DSN,
+    enable: !['development', 'test'].includes(ENV_NAME),
+  });
 }
 
 const Wrapper = () => (

--- a/services/web/src/utils/env.js
+++ b/services/web/src/utils/env.js
@@ -1,17 +1,4 @@
-const {
-  DEV,
-  PROD,
-  STAGING,
-  API_URL,
-  APP_NAME,
-  SENTRY_DSN,
-} = window.__ENV__ || {};
+const { DEV, PROD, STAGING, API_URL, APP_NAME, SENTRY_DSN, ENV_NAME } =
+  window.__ENV__ || {};
 
-export {
-  DEV,
-  PROD,
-  STAGING,
-  API_URL,
-  APP_NAME,
-  SENTRY_DSN,
-};
+export { DEV, PROD, STAGING, API_URL, APP_NAME, SENTRY_DSN, ENV_NAME };

--- a/services/web/src/utils/sentry.js
+++ b/services/web/src/utils/sentry.js
@@ -1,0 +1,9 @@
+import * as Sentry from '@sentry/browser';
+import { SENTRY_DSN, ENV_NAME } from 'utils/env';
+
+if (SENTRY_DSN) {
+  Sentry.init({
+    dsn: SENTRY_DSN,
+    enable: !['development', 'test'].includes(ENV_NAME),
+  });
+}

--- a/services/web/src/utils/sentry.js
+++ b/services/web/src/utils/sentry.js
@@ -1,9 +1,8 @@
 import * as Sentry from '@sentry/browser';
 import { SENTRY_DSN, ENV_NAME } from 'utils/env';
 
-if (SENTRY_DSN) {
+if (SENTRY_DSN && !['development', 'test'].includes(ENV_NAME)) {
   Sentry.init({
-    dsn: SENTRY_DSN,
-    enable: !['development', 'test'].includes(ENV_NAME),
+    dsn: SENTRY_DSN
   });
 }

--- a/services/web/yarn.lock
+++ b/services/web/yarn.lock
@@ -1543,6 +1543,58 @@
     exenv "^1.2.2"
     prop-types "^15.6.2"
 
+"@sentry/browser@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.0.1.tgz#5d0b8e3bc893c1c7e55a9238e23ed47adf264fa2"
+  integrity sha512-iP8Bqxj4Ye8CXA4ja77buPZfXsKiZYUgHFzBQxVMihTHA8ZZLgBMPLQI6uFfHuJJW+1/yLzOf8BhvF2zknAebg==
+  dependencies:
+    "@sentry/core" "6.0.1"
+    "@sentry/types" "6.0.1"
+    "@sentry/utils" "6.0.1"
+    tslib "^1.9.3"
+
+"@sentry/core@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.0.1.tgz#4024b2b04e5ce78ce35d7795a283fbd235f37757"
+  integrity sha512-EoxgodyClasI8PA4GyU8Cp88W3R5ebpiLsE7fCcBcOU0DOBRkO8GAZ5IzfCDtYDJ50c9npivum5Oyj2wf8CXYw==
+  dependencies:
+    "@sentry/hub" "6.0.1"
+    "@sentry/minimal" "6.0.1"
+    "@sentry/types" "6.0.1"
+    "@sentry/utils" "6.0.1"
+    tslib "^1.9.3"
+
+"@sentry/hub@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.0.1.tgz#6a338522f62d6d6282822e16da4385a5a854f0a8"
+  integrity sha512-pGckNdhKcr7qYVXgSgA/QVGArATcmQu54YFAR5xTnkWVHpAwNmh0fc4CJCc4JBwS/LXSU1Y0nYiLQduVfnv8Cg==
+  dependencies:
+    "@sentry/types" "6.0.1"
+    "@sentry/utils" "6.0.1"
+    tslib "^1.9.3"
+
+"@sentry/minimal@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.0.1.tgz#f970a59b024d08e61e00d518081eb4b7591f3d77"
+  integrity sha512-TQ/M5A+OsxtQJ8dzHwrclxKXpJNdQeM1PUoYhff4BvsOXJScvZb7+Yn0OUEQXEc9pSMNt62tnQy4ct80iAMTHw==
+  dependencies:
+    "@sentry/hub" "6.0.1"
+    "@sentry/types" "6.0.1"
+    tslib "^1.9.3"
+
+"@sentry/types@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.0.1.tgz#4d1a281a4a79541b607361523e08058c6676409e"
+  integrity sha512-cEoe19vtam75Tf6eWmaobfbeV8XwBdr5FJoSVTomzcSsEiP2FHGOEhlE7kVBigzeH5Lri0aibiW6BDi1hIqHdg==
+
+"@sentry/utils@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.0.1.tgz#061ef604df519e1488960484e9bf0cbcb8d8c9a4"
+  integrity sha512-bjGuBYnG6fulZ8mLhPGBxttNu96DCN6d7Glw2sfLf4aurn1kjJ/58hP2c8dH0OqWO5e+rGYTsZ5Dr5kqVKNGTg==
+  dependencies:
+    "@sentry/types" "6.0.1"
+    tslib "^1.9.3"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
@@ -10648,7 +10700,7 @@ tryer@^1.0.1:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
-tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
Sentry supports loading its JavaScript SDK via a CDN. Generally we suggest using our npm package (@sentry/browser) as utilizing a CDN create scenarios where Sentry is unable to load due to networking issues or common extensions like ad blockers. If you must use a CDN, take a look at loading Sentry lazily with our JS loader.

via https://docs.sentry.io/platforms/javascript/install/cdn/#using-defer