### PR TITLE
Hide token implementation

### DIFF
--- a/services/web/__mocks__/fileMock.js
+++ b/services/web/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/services/web/__mocks__/styleMock.js
+++ b/services/web/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/services/web/jest.config.js
+++ b/services/web/jest.config.js
@@ -4,8 +4,8 @@ module.exports = {
   moduleDirectories: ['node_modules', './src/', './serve'],
   testPathIgnorePatterns: ['node_modules', '\\w+.ignore.js'],
   moduleNameMapper: {
-    '\\.(css|less)$': '<rootDir>/src/utils/test/mocks/styles.js',
+    '\\.(css|less)$': '<rootDir>/__mocks__/styleMock.js',
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
-      '<rootDir>/src/utils/test/mocks/files.js',
+    '<rootDir>/__mocks__/fileMock.js',
   },
 };

--- a/services/web/src/semantic/elements/Icon.js
+++ b/services/web/src/semantic/elements/Icon.js
@@ -12,9 +12,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Icon as SemanticIcon } from 'semantic-ui-react';
-import { createShorthandFactory } from 'semantic-ui-react/dist/es/lib/factories';
 import IconGroup from './IconGroup';
 import { omit } from 'lodash';
+
+// Note Jest is too convoluted to be able to
+// load this file from modules. This can move to src
+// when esm support lands.
+import { createShorthandFactory } from 'semantic-ui-react/dist/commonjs/lib/factories';
 
 import regularSet from '../assets/icons/regular.svg';
 import outlineSet from '../assets/icons/outline.svg';

--- a/services/web/src/stores/__tests__/session.test.js
+++ b/services/web/src/stores/__tests__/session.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { SessionProvider, withSession, withLoadedSession, useSession } from '../session';
-import { getToken, setToken, clearToken } from 'utils/api';
+import { setToken, clearToken } from 'utils/api';
 import { render } from '@testing-library/react';
 
 jest.mock('utils/api');

--- a/services/web/src/stores/__tests__/session.test.js
+++ b/services/web/src/stores/__tests__/session.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { SessionProvider, withSession, withLoadedSession, useSession } from '../session';
+import { getToken, setToken, clearToken } from 'utils/api';
 import { render } from '@testing-library/react';
 
 jest.mock('utils/api');
@@ -14,7 +15,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  localStorage.clear();
+  clearToken();
 });
 
 class MyComponent extends React.Component {
@@ -52,7 +53,7 @@ describe('withSession', () => {
   });
 
   it('should display user name', async () => {
-    localStorage.setItem('jwt', 'fake');
+    setToken('fake');
     const { container } = await render(
       <SessionProvider>
         <Component />
@@ -63,7 +64,7 @@ describe('withSession', () => {
   });
 
   it('should set the last context as a snapshot', async () => {
-    localStorage.setItem('jwt', 'fake');
+    setToken('fake');
     await render(
       <SessionProvider>
         <Component />
@@ -91,7 +92,7 @@ describe('withLoadedSession', () => {
   });
 
   it('should display user name', async () => {
-    localStorage.setItem('jwt', 'fake');
+    setToken('fake');
     const { container } = await render(
       <SessionProvider>
         <Component />
@@ -126,7 +127,7 @@ describe('useSession', () => {
   });
 
   it('should display user name', async () => {
-    localStorage.setItem('jwt', 'fake');
+    setToken('fake');
     const { container } = await render(
       <SessionProvider>
         <Component />

--- a/services/web/src/stores/session.js
+++ b/services/web/src/stores/session.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { merge, omit } from 'lodash';
-import { request } from 'utils/api';
+import { request, getToken, setToken, clearToken } from 'utils/api';
 import { trackSession } from 'utils/analytics';
 
 const SessionContext = React.createContext();
@@ -37,14 +37,14 @@ export class SessionProvider extends React.PureComponent {
 
   setToken = async (token) => {
     if (token) {
-      localStorage.setItem('jwt', token);
+      setToken(token);
     } else {
-      localStorage.removeItem('jwt');
+      clearToken();
     }
   };
 
   loadUser = async () => {
-    if (localStorage.getItem('jwt')) {
+    if (getToken()) {
       this.setState({
         loading: true,
         error: null,

--- a/services/web/src/utils/api/__mocks__/index.js
+++ b/services/web/src/utils/api/__mocks__/index.js
@@ -1,1 +1,2 @@
 export { default as request } from './request';
+export * from '../token';

--- a/services/web/src/utils/api/index.js
+++ b/services/web/src/utils/api/index.js
@@ -1,2 +1,3 @@
+export * from './token';
 export * from './errors';
 export { default as request } from './request';

--- a/services/web/src/utils/api/request.js
+++ b/services/web/src/utils/api/request.js
@@ -1,12 +1,13 @@
 import { API_URL } from 'utils/env';
 import { ApiError, ApiParseError } from './errors';
 import { trackRequest } from '../analytics';
+import { getToken } from '../token';
 
 export default async function request(options) {
   const { method = 'GET', path, files, params } = options;
   let { body } = options;
 
-  const token = options.token || localStorage.getItem('jwt');
+  const token = options.token || getToken();
 
   const headers = Object.assign(
     {

--- a/services/web/src/utils/api/token.js
+++ b/services/web/src/utils/api/token.js
@@ -1,0 +1,13 @@
+const KEY = 'jwt';
+
+export function getToken() {
+  return localStorage.getItem(KEY);
+}
+
+export function setToken(token) {
+  localStorage.setItem(KEY, token);
+}
+
+export function clearToken() {
+  localStorage.removeItem(KEY);
+}


### PR DESCRIPTION
I've spent some time going over JWT best practices and doing a deep dive into the details of storing the tokens:

## Breakdown

### Local Storage

localStorage is perceived to be insecure because it's "more" vulnerable to XSS. "more" means it can be directly read out with JS.

### HTTP Cookie

HTTP only cookies are perceived to be secure, however they suffer CSRF vulnerability. This is mitigated by methods like "double submit" CSRF tokens which incur overhead. These methods mitigate CSRF attacks but what is generally not known is that it opens them back up to XSS attacks as the methods involve reading the CSRF token itself out via JS. Additionally, HTTP cookies are generally only "secure" when they are same-site only, which limits them further and has implications for SSO.

### In Memory

In memory solutions are less known but also perceived to be secure. They require requesting a new access token via a refresh token that is also held in an HTTP only cookie. This means that it is something of a hybrid. Requests can be made cross domain via normal Bearer scheme, however a /refresh_token endpoint needs to be set up on the same domain. Every time the page is refreshed or navigated away, a new access token must be requested by this refresh mechanism and retained in memory, as well as when the access token expires. This method is considered secure as you cannot access the token directly, however a determined XSS attack could still grab it fairly easily, for example by overwriting the fetch method and intercepting the headers.


## Conclusion

Although the current accepted methods of securing the JWT token (HTTP only cookies / In Memory) do provide more XSS security, neither of them provide 100% protection. They also come at a rather large cost, whether it's server overhead or same-domain policies.

We would like to move to a more secure model, however given these limiting factors it seems like there are other domains of security (password brute force attacks etc) where out time would be better spent for now.

Basically this PR is a preparation step that tucks away the implementation of JWT token storage so that it can readily be swapped out for a more secure method, either in individual products or here as standards evolve.

## Sources

https://stackoverflow.com/questions/34817617/should-jwt-be-stored-in-localstorage-or-cookie
https://hasura.io/blog/best-practices-of-using-jwt-with-graphql/
https://medium.com/@ryanchenkie_40935/react-authentication-how-to-store-jwt-in-a-cookie-346519310e81

