### PR TITLE
docker-compose is not not good for development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,11 @@ version: "3.7"
 
 services:
   api:
-    command: ["./scripts/wait-for-it.sh", "mongo:27017", "--", "yarn", "start"]
     environment:
       - MONGO_URI=mongodb://mongo/bedrock_dev
     build:
       context: ./services/api
       dockerfile: Dockerfile
-      args:
-        NODE_ENV: development
     volumes:
       - ./services/api/src:/service/src
       - ./services/api/emails:/service/emails
@@ -25,12 +22,9 @@ services:
       - mongo
 
   web:
-    command: ["yarn", "start"]
     build:
       context: ./services/web
       dockerfile: Dockerfile
-      args:
-        NODE_ENV: development
     volumes:
       - ./services/web/src:/service/src
     ports:


### PR DESCRIPTION
I think i am the only that are using the docker-compose for development, e.g. mainly use it for launching the api (and mongo). (saves me a one tab, and the volumes are useful)

For `web` it's not really possible todo use, its just too slow. 
I am thinking its not worth the effort to use as dev environment. 

So i want to switch it back to be just a simple docker-compose file, without dev mode.

 


