### PR TITLE
managed dialog with animation

### DIFF
--- a/services/web/src/components/semantic/ManagedModal.js
+++ b/services/web/src/components/semantic/ManagedModal.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Modal, Transition } from 'semantic';
+
+export default class ManagedModal extends React.Component {
+  state = {
+    open: false,
+  };
+
+  onClose = () => {
+    this.setState({ open: false });
+    if (this.props.onClose) this.props.onClose();
+  };
+
+  onOpen = () => {
+    this.setState({ open: true });
+    if (this.props.onOpen) this.props.onOpen();
+  };
+
+  render() {
+    const {
+      onClose,
+      onOpen,
+      open = this.state.open,
+      closeIcon = true,
+      closeOnDimmerClick = false,
+      trigger,
+      content,
+      ...rest
+    } = this.props;
+
+    return (
+      <>
+        {React.cloneElement(this.props.trigger, {
+          ...rest,
+          onClick: this.onOpen,
+        })}
+
+        <Transition visible={open} animation="scale" duration={500}>
+          <Modal
+            closeIcon={closeIcon}
+            closeOnDimmerClick={closeOnDimmerClick}
+            onOpen={this.onOpen}
+            onClose={this.onClose}
+            open={open}>
+            {open &&
+              React.cloneElement(this.props.content, {
+                ...rest,
+                close: this.onClose,
+              })}
+          </Modal>
+        </Transition>
+      </>
+    );
+  }
+}
+
+ManagedModal.propTypes = {
+  ...Modal.propTypes,
+  content: PropTypes.node.isRequired,
+  trigger: PropTypes.node.isRequired,
+};

--- a/services/web/src/components/semantic/index.js
+++ b/services/web/src/components/semantic/index.js
@@ -1,1 +1,2 @@
 export { default as Confirm } from './Confirm';
+export { default as ManagedModal } from './ManagedModal';

--- a/services/web/src/modals/EditShop.js
+++ b/services/web/src/modals/EditShop.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Form, Modal, Message, Button } from 'semantic';
+import { Form, Message, Button } from 'semantic';
 import { request } from 'utils/api';
-import AutoFocus from 'components/AutoFocus';
+import { Modal } from 'semantic';
 
 // --- Generator: imports
 import UploadsField from 'components/form-fields/Uploads';
@@ -10,7 +10,6 @@ import CategoriesField from 'components/form-fields/Categories';
 // --- Generator: end
 
 export default class EditShop extends React.Component {
-
   constructor(props) {
     super(props);
     this.state = {
@@ -19,15 +18,6 @@ export default class EditShop extends React.Component {
       loading: false,
       shop: props.shop || {},
     };
-  }
-
-  componentDidUpdate(lastProps) {
-    const { shop } = this.props;
-    if (shop && shop !== lastProps.shop) {
-      this.setState({
-        shop,
-      });
-    }
   }
 
   isUpdate() {
@@ -41,14 +31,6 @@ export default class EditShop extends React.Component {
         [name]: value,
       },
     });
-  };
-
-  setCheckedField = (evt, { name, checked }) => {
-    this.setField(evt, { name, value: checked });
-  };
-
-  setNumberField = (evt, { name, value }) => {
-    this.setField(evt, { name, value: Number(value) });
   };
 
   onSubmit = async () => {
@@ -70,15 +52,9 @@ export default class EditShop extends React.Component {
           path: '/1/shops',
           body: shop,
         });
-        this.setState({
-          shop: {},
-        });
       }
-      this.setState({
-        open: false,
-        loading: false,
-      });
       this.props.onSave();
+      this.props.onClose();
     } catch (error) {
       this.setState({
         error,
@@ -88,53 +64,55 @@ export default class EditShop extends React.Component {
   };
 
   render() {
-    const { trigger } = this.props;
-    const { shop, open, loading, error } = this.state;
+    const { shop, loading, error } = this.state;
     return (
-      <Modal
-        closeIcon
-        open={open}
-        trigger={trigger}
-        closeOnDimmerClick={false}
-        onOpen={() => this.setState({ open: true })}
-        onClose={() => this.setState({ open: false })}>
-        <Modal.Header>{this.isUpdate() ? `Edit "${shop.name}"` : 'New Shop'}</Modal.Header>
+      <>
+        <Modal.Header>
+          {this.isUpdate() ? `Edit "${shop.name}"` : 'New Shop'}
+        </Modal.Header>
         <Modal.Content scrolling>
-          <AutoFocus>
-            <Form
-              noValidate
-              id="edit-shop"
-              error={!!error}
-              onSubmit={this.onSubmit}>
-              {error && <Message error content={error.message} />}
-              {/* --- Generator: fields */}
-              <Form.Input
-                required
-                type="text"
-                name="name"
-                label="Name"
-                value={shop.name || ''}
-                onChange={this.setField}
-              />
-              <Form.TextArea
-                name="description"
-                label="Description"
-                type="text"
-                value={shop.description || ''}
-                onChange={this.setField}
-              />
-              <CountriesField label="Country" name="country" value={shop.country || ''} onChange={this.setField} />
-              <CategoriesField name="categories" value={shop.categories || []} onChange={this.setField} />
-              <UploadsField
-                name="images"
-                label="Images"
-                value={shop.images || []}
-                onChange={(data) => this.setField(null, data)}
-                onError={(error) => this.setState({ error })}
-              />
-              {/* --- Generator: end */}
-            </Form>
-          </AutoFocus>
+          <Form
+            noValidate
+            id="edit-shop"
+            error={!!error}
+            onSubmit={this.onSubmit}>
+            {error && <Message error content={error.message} />}
+            {/* --- Generator: fields */}
+            <Form.Input
+              required
+              type="text"
+              name="name"
+              label="Name"
+              value={shop.name || ''}
+              onChange={this.setField}
+            />
+            <Form.TextArea
+              name="description"
+              label="Description"
+              type="text"
+              value={shop.description || ''}
+              onChange={this.setField}
+            />
+            <CountriesField
+              label="Country"
+              name="country"
+              value={shop.country || ''}
+              onChange={this.setField}
+            />
+            <CategoriesField
+              name="categories"
+              value={shop.categories || []}
+              onChange={this.setField}
+            />
+            <UploadsField
+              name="images"
+              label="Images"
+              value={shop.images || []}
+              onChange={(data) => this.setField(null, data)}
+              onError={(error) => this.setState({ error })}
+            />
+            {/* --- Generator: end */}
+          </Form>
         </Modal.Content>
         <Modal.Actions>
           <Button
@@ -145,7 +123,7 @@ export default class EditShop extends React.Component {
             content={this.isUpdate() ? 'Update' : 'Create'}
           />
         </Modal.Actions>
-      </Modal>
+      </>
     );
   }
 }

--- a/services/web/src/screens/Shops/List/index.js
+++ b/services/web/src/screens/Shops/List/index.js
@@ -4,7 +4,13 @@ import { Table, Divider, Button, Message } from 'semantic';
 import { formatDateTime } from 'utils/date';
 import { request } from 'utils/api';
 import { screen } from 'helpers';
-import { Confirm, HelpTip, Breadcrumbs, SearchProvider } from 'components';
+import {
+  Confirm,
+  HelpTip,
+  Breadcrumbs,
+  SearchProvider,
+  ManagedModal,
+} from 'components';
 
 import Filters from 'modals/Filters';
 import EditShop from 'modals/EditShop';
@@ -58,7 +64,11 @@ export default class ShopList extends React.Component {
               <Breadcrumbs active="Shops">
                 <Filters onSave={setFilters} filters={filters}>
                   {/* --- Generator: filters */}
-                  <Filters.Text label="Search" name="keyword" placeholder="Enter name or shop id" />
+                  <Filters.Text
+                    label="Search"
+                    name="keyword"
+                    placeholder="Enter name or shop id"
+                  />
                   <Filters.Dropdown
                     label="Country"
                     name="country"
@@ -72,9 +82,9 @@ export default class ShopList extends React.Component {
                   />
                   {/* --- Generator: end */}
                 </Filters>
-                <EditShop
+                <ManagedModal
                   trigger={<Button primary content="New Shop" icon="plus" />}
-                  onSave={reload}
+                  content={<EditShop onSave={reload} />}
                 />
               </Breadcrumbs>
               <Divider hidden />
@@ -121,8 +131,7 @@ export default class ShopList extends React.Component {
                             {formatDateTime(shop.createdAt)}
                           </Table.Cell>
                           <Table.Cell textAlign="center">
-                            <EditShop
-                              shop={shop}
+                            <ManagedModal
                               trigger={
                                 <Button
                                   style={{ marginLeft: '20px' }}
@@ -130,7 +139,7 @@ export default class ShopList extends React.Component {
                                   icon="edit"
                                 />
                               }
-                              onSave={reload}
+                              content={<EditShop shop={shop} onSave={reload} />}
                             />
                             <Confirm
                               negative


### PR DESCRIPTION
This adds a managed dialog where you don't have to deal with dialog state.
 - You don't have to recall to reset the state of the dialog when you close it (common bug)
- You don't have have to deal with lifecycles (assume you are not planning to update the e.g. product (from outside via props) while you have the edit product dialog open)

I also added a bit of animation (which i think could be tweaked a bit more ... i think the dimmer (background) could be faded in instead of appearing suddenly)

see https://monosnap.com/file/ke29s4dqYXpZIZIj10lqRignOIIefr

If people agree then i would like convert all modals to be managedModals
