### PR TITLE
avoid try and catch in route

### DIFF
--- a/services/api/src/models/user.js
+++ b/services/api/src/models/user.js
@@ -1,5 +1,4 @@
 const mongoose = require('mongoose');
-const { logger } = require('@bedrockio/instrumentation');
 const bcrypt = require('bcrypt');
 const { mapExponential } = require('../utils/math');
 const { createSchema } = require('../utils/schema');
@@ -20,8 +19,7 @@ const schema = createSchema(definition.attributes);
 
 schema.methods.verifyPassword = async function verifyPassword(password) {
   if (!this.hashedPassword) {
-    logger.error(`Can't verifyPassword as no password is set`, { userId: this.id, email: this.email });
-    return Promise.resolve(false);
+    throw Error('No password set for user');
   }
   return bcrypt.compare(password, this.hashedPassword);
 };

--- a/services/api/src/routes/auth.js
+++ b/services/api/src/routes/auth.js
@@ -63,20 +63,22 @@ router
           $inc: { loginAttempts: 1 },
         }
       );
-      if (user) {
-        try {
-          user.verifyLoginAttempts();
-          await user.verifyPassword(password);
 
-          const authTokenId = generateTokenId();
-          await user.updateOne({ loginAttempts: 0, authTokenId });
-          ctx.body = { data: { token: createAuthToken(user.id, authTokenId) } };
-        } catch (err) {
-          ctx.throw(401, err.message);
-        }
-      } else {
+      if (!user) {
         ctx.throw(401, 'Incorrect password');
       }
+
+      if (!user.verifyLoginAttempts()) {
+        ctx.throw(401, 'Too many login attempts');
+      }
+
+      if (!(await user.verifyPassword(password))) {
+        ctx.throw(401, 'Incorrect password');
+      }
+
+      const authTokenId = generateTokenId();
+      await user.updateOne({ loginAttempts: 0, authTokenId });
+      ctx.body = { data: { token: createAuthToken(user.id, authTokenId) } };
     }
   )
   .post(


### PR DESCRIPTION
My goal here was to avoid hidden any errors which means removing the try and catch in the login route. 

If bcrypt or the db failed, syntax error ... or something totally else the request will be marked as a 401 instead of 500, and hide the underlining error. The error wont be captured correctly. We should rely on the global error handler.

I think the pattern here i should be don't throw errors outside of the route, unless you mean to trigger an 500.
