### PR TITLE
Write scopes

### DIFF
--- a/services/api/src/utils/schema.js
+++ b/services/api/src/utils/schema.js
@@ -55,18 +55,12 @@ function createSchema(attributes = {}, options = {}) {
 
   schema.static('getCreateValidation', function getCreateValidation(appendSchema) {
     return getJoiSchemaFromMongoose(schema, {
-      disallowField: (key) => {
-        return isDisallowedField(this.schema.obj[key]);
-      },
       appendSchema,
     });
   });
 
   schema.static('getUpdateValidation', function getUpdateValidation(appendSchema) {
     return getJoiSchemaFromMongoose(schema, {
-      disallowField: (key) => {
-        return isDisallowedField(this.schema.obj[key]);
-      },
       appendSchema,
       skipRequired: true,
     });

--- a/services/api/src/utils/validation.js
+++ b/services/api/src/utils/validation.js
@@ -90,6 +90,8 @@ function getSchemaForField(field, options = {}) {
 
   if (field.required && !options.skipRequired) {
     schema = schema.required();
+  } else if (field.writeScopes) {
+    schema = schema.custom(validateScopes(field.writeScopes));
   } else {
     // TODO: for now we allow both empty strings and null
     // as a potential signal for "set but non-existent".
@@ -111,6 +113,23 @@ function getSchemaForField(field, options = {}) {
     schema = schema.max(field.max || field.maxLength);
   }
   return schema;
+}
+
+function validateScopes(scopes) {
+  return (val, { prefs }) => {
+    let allowed = false;
+    if (scopes === 'all') {
+      allowed = true;
+    } else if (Array.isArray(scopes)) {
+      allowed = scopes.some((scope) => {
+        return prefs.scopes?.includes(scope);
+      });
+    }
+    if (!allowed) {
+      throw new Error(`Validation failed for scopes ${scopes}.`);
+    }
+    return val;
+  };
 }
 
 function getSchemaForType(type) {

--- a/services/api/src/utils/validation.js
+++ b/services/api/src/utils/validation.js
@@ -21,10 +21,7 @@ function getJoiSchema(attributes, options = {}) {
 function getMongooseValidator(schemaName, field) {
   const schema = getSchemaForField(field);
   const validator = (val) => {
-    const { error } = schema.validate(val);
-    if (error) {
-      throw error;
-    }
+    Joi.assert(val, schema);
     return true;
   };
   // A named shortcut back to the Joi schema to retrieve it


### PR DESCRIPTION
This is the first of 2 PRs for moving our field based access control to allow "scopes".

The first will allow "writeScopes" per-field. This will basically create a custom Joi validator that will match against passed in `scopes` in the options. This is the groundwork that is intentionally not tied to our `roles` definitions in any way, however the next step will be to connect those two together.

The other PR will essentially move `access: 'private'` to "readScopes" that will compliment "writeScopes". It will be more or less the same functionally except that instead of being off/on it will check against a potential array of scopes similar to writeScopes.

Note also that `none` is a signal to not allow any scopes, otherwise all scopes will be allowed.