### PR TITLE
Feature/soft delete

### DIFF
--- a/services/api/package.json
+++ b/services/api/package.json
@@ -31,6 +31,7 @@
     "marked": "^2.0.1",
     "mongoose": "^5.9.26",
     "mongoose-autopopulate": "^0.12.2",
+    "mongoose-delete": "^0.5.3",
     "mustache": "^4.1.0",
     "postmark": "^2.5.4"
   },

--- a/services/api/src/routes/__tests__/invites.js
+++ b/services/api/src/routes/__tests__/invites.js
@@ -82,7 +82,7 @@ describe('/1/invites', () => {
       });
       const response = await request('DELETE', `/1/invites/${invite.id}`, {}, { user });
       expect(response.status).toBe(204);
-      const dbInvite = await Invite.findById(invite.id);
+      const dbInvite = await Invite.findOneDeleted({ _id: invite.id });
       expect(dbInvite.deletedAt).toBeDefined();
     });
   });

--- a/services/api/src/routes/__tests__/products.js
+++ b/services/api/src/routes/__tests__/products.js
@@ -98,7 +98,7 @@ describe('/1/products', () => {
       });
       const response = await request('DELETE', `/1/products/${product.id}`, {}, { user });
       expect(response.status).toBe(204);
-      const dbProduct = await Product.findById(product.id);
+      const dbProduct = await Product.findOneDeleted({ _id: product.id });
       expect(dbProduct.deletedAt).toBeDefined();
     });
   });

--- a/services/api/src/routes/__tests__/shops.js
+++ b/services/api/src/routes/__tests__/shops.js
@@ -99,8 +99,8 @@ describe('/1/shops', () => {
       });
       const response = await request('DELETE', `/1/shops/${shop.id}`, {}, { user });
       expect(response.status).toBe(204);
-      shop = await Shop.findById(shop.id);
-      expect(shop.deletedAt).toBeDefined();
+      const dbShop = await Shop.findOneDeleted({ _id: shop.id });
+      expect(dbShop.deletedAt).toBeDefined();
       // --- Generator: end
     });
   });

--- a/services/api/src/routes/__tests__/uploads.js
+++ b/services/api/src/routes/__tests__/uploads.js
@@ -70,7 +70,7 @@ describe('/1/uploads', () => {
       const upload = await createUpload(user);
       const response = await request('DELETE', `/1/uploads/${upload.id}`, {}, { user });
       expect(response.status).toBe(204);
-      const dbUpload = await Upload.findById(upload.id);
+      const dbUpload = await Upload.findOneDeleted({ _id: upload.id });
       expect(dbUpload.deletedAt).toBeDefined();
     });
 

--- a/services/api/src/routes/__tests__/users.js
+++ b/services/api/src/routes/__tests__/users.js
@@ -212,9 +212,11 @@ describe('/1/users', () => {
       const user1 = await createUser({ name: 'One' });
       const response = await request('DELETE', `/1/users/${user1.id}`, {}, { user: admin });
       expect(response.status).toBe(204);
-      const dbUser = await User.findById(user1._id);
+
+      const dbUser = await User.findOneDeleted({ _id: user1._id });
       expect(dbUser.deletedAt).toBeDefined();
     });
+
     it('should deny access to non-admins', async () => {
       const user = await createUser({});
       const user1 = await createUser({ name: 'One' });

--- a/services/api/src/routes/auth.js
+++ b/services/api/src/routes/auth.js
@@ -23,7 +23,7 @@ router
     }),
     async (ctx) => {
       const { email, name } = ctx.request.body;
-      const existingUser = await User.findOne({ email, deletedAt: { $exists: false } });
+      const existingUser = await User.findOne({ email });
       if (existingUser) {
         throw new BadRequestError('A user with that email already exists');
       }

--- a/services/api/src/routes/users.js
+++ b/services/api/src/routes/users.js
@@ -104,7 +104,7 @@ router
     ),
     async (ctx) => {
       const { email } = ctx.request.body;
-      const existingUser = await User.findOne({ email, deletedAt: { $exists: false } });
+      const existingUser = await User.findOne({ email });
       if (existingUser) {
         throw new BadRequestError('A user with that email already exists');
       }

--- a/services/api/src/utils/schema.js
+++ b/services/api/src/utils/schema.js
@@ -89,6 +89,7 @@ function createSchema(attributes = {}, options = {}) {
     return this.save();
   };
 
+  schema.plugin(require('mongoose-autopopulate'));
   return schema;
 }
 
@@ -176,7 +177,6 @@ function loadModel(definition, name) {
     throw new Error(`Invalid model definition for ${name}, need attributes`);
   }
   const schema = createSchema(attributes);
-  schema.plugin(require('mongoose-autopopulate'));
   return mongoose.model(name, schema);
 }
 

--- a/services/api/src/utils/schema.js
+++ b/services/api/src/utils/schema.js
@@ -1,6 +1,8 @@
 const mongoose = require('mongoose');
 const fs = require('fs');
 const path = require('path');
+const pluginAutoPopulate = require('mongoose-autopopulate');
+
 const { startCase, omitBy, isPlainObject } = require('lodash');
 const { ObjectId } = mongoose.Schema.Types;
 const { getJoiSchema, getMongooseValidator } = require('./validation');
@@ -89,7 +91,7 @@ function createSchema(attributes = {}, options = {}) {
     return this.save();
   };
 
-  schema.plugin(require('mongoose-autopopulate'));
+  schema.plugin(pluginAutoPopulate);
   return schema;
 }
 

--- a/services/api/src/utils/search.js
+++ b/services/api/src/utils/search.js
@@ -34,7 +34,7 @@ function exportValidation(options = {}) {
 function getSearchQuery(body, options = {}) {
   const { keyword, startAt, endAt, ids = [] } = body;
   const { keywordFields = [] } = options;
-  const query = { deletedAt: { $exists: false } };
+  const query = {};
   if (startAt || endAt) {
     query.createdAt = {};
     if (startAt) {

--- a/services/api/yarn.lock
+++ b/services/api/yarn.lock
@@ -5121,6 +5121,11 @@ mongoose-autopopulate@^0.12.2:
   resolved "https://registry.yarnpkg.com/mongoose-autopopulate/-/mongoose-autopopulate-0.12.3.tgz#5bf111db3fa485f5031d3303f6f25625304888e3"
   integrity sha512-yNmYsfi6OpS/GQ+48mkB0KQ199ExHmmPrt3wt3fyxPHPMtEBGts7yq3wBQR6VgKCPOQaKvCI1URbJCPOtrPeLw==
 
+mongoose-delete@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mongoose-delete/-/mongoose-delete-0.5.3.tgz#c35c2147ca6c460af54cfd3f3f9fb656ac6a0dc0"
+  integrity sha512-7RdnGf7U9Bzp0F0ovW2C00G0otj7OltB1HdmL3ElX5EgjtqfBupq+22sYbhbQ/74+zCIkx37nsNaKYHFVWDm2w==
+
 mongoose-legacy-pluralize@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz#3ba9f91fa507b5186d399fb40854bff18fb563e4"


### PR DESCRIPTION
This implements soft delete so we don't have to recall todo `deletedAt: { $exists: false } `
```
 const existingUser = await User.findOne({ email, deletedAt: { $exists: false } });
```
Common bug, even in this repo the the products endpoint is not configured correctly.

## The Mongoose-delete Plugin
I am using https://github.com/dsanel/mongoose-delete. Which is nearly perfect.
Its configured to hook into find/findOne/countDocument and avoid those query to return delete items. Note that findOne is used when calling findById via mongoose (no way to have it enabled on findOne and not have it enabled for findById)

We can also add to count, update, updateMany, aggregate, I think it's better to avoid those as we used those methods rarely and when we do its often to do some atomic or advanced query.

It also providers new methods to look up deleted items

only not deleted documents | only deleted documents | all documents
-- | -- | --
countDocuments() | countDocumentsDeleted | countDocumentsWithDeleted
find() | findDeleted | findWithDeleted
findOne() | findOneDeleted | findOneWithDeleted

see https://github.com/dsanel/mongoose-delete#method-overridden

It also providers model.`delete` model.`restore`

### The unwanted deleted field
This is part where i think its less than perfect this plugin adds a `deleted : boolean` attribute, besides deletedAt. From what I call tell its done to make queries quicker (I have updated the utils/schema to filter out that field, but not in most elegant way) 

Other theories https://github.com/dsanel/mongoose-delete/issues/82 


