### PR TITLE
Read scopes & mixed validation

### DIFF
--- a/services/api/src/models/__tests__/user.js
+++ b/services/api/src/models/__tests__/user.js
@@ -16,7 +16,7 @@ describe('User', () => {
       expect(data.__v).toBeUndefined();
     });
 
-    it('should not expose _password or hashedPassword serialize', () => {
+    it('should not expose _password or hashedPassword', () => {
       const user = new User({
         password: 'fake password',
         hashedPassword: 'fake hash',
@@ -30,15 +30,6 @@ describe('User', () => {
       expect(data.hashedPassword).toBeUndefined();
     });
 
-    it('should not allow hashedPassword to be set via assignment', () => {
-      const user = new User({
-        hashedPassword: 'fake hash',
-      });
-      user.assign({
-        hashPassword: 'new fake hash',
-      });
-      expect(user.hashedPassword).toBe('fake hash');
-    });
   });
 
   describe('validation', () => {

--- a/services/api/src/models/definitions/user.json
+++ b/services/api/src/models/definitions/user.json
@@ -24,24 +24,29 @@
     },
     "hashedPassword": {
       "type": "String",
-      "access": "private"
+      "readScopes": "none",
+      "writeScopes": "none"
     },
     "loginAttempts": {
       "type": "Number",
-      "access": "private",
-      "default": 0
+      "default": 0,
+      "readScopes": "none",
+      "writeScopes": "none"
     },
     "lastLoginAttemptAt": {
       "type": "Date",
-      "access": "private"
+      "readScopes": "none",
+      "writeScopes": "none"
     },
     "authTokenId": {
       "type": "String",
-      "access": "private"
+      "readScopes": "none",
+      "writeScopes": "none"
     },
     "tempTokenId": {
       "type": "String",
-      "access": "private"
+      "readScopes": "none",
+      "writeScopes": "none"
     }
   }
 }

--- a/services/api/src/routes/__tests__/users.js
+++ b/services/api/src/routes/__tests__/users.js
@@ -72,6 +72,7 @@ describe('/1/users', () => {
       expect(response.status).toBe(200);
       expect(data.name).toBe('Hello');
     });
+
     it('should deny access to non-admins', async () => {
       const user = await createUser({});
       const response = await request(
@@ -190,6 +191,7 @@ describe('/1/users', () => {
       expect(dbUser.roles[0].role).toBe('limitedAdmin');
       expect(dbUser.roles[0].scope).toBe('global');
     });
+
     it('should strip out reserved fields', async () => {
       const admin = await createUserWithRole('global', 'superAdmin');
       const user1 = await createUser({ name: 'new name' });
@@ -204,6 +206,21 @@ describe('/1/users', () => {
       const dbUser = await User.findById(user1.id);
       expect(dbUser.name).toEqual('new name');
     });
+
+    it('should fail when trying to set hashed password', async () => {
+      const admin = await createUserWithRole('global', 'superAdmin');
+      const user = await createUser({ name: 'new name' });
+      const response = await request(
+        'PATCH',
+        `/1/users/${user.id}`,
+        {
+          hashedPassword: 'new hashed password'
+        },
+        { user: admin }
+      );
+      expect(response.status).toBe(401);
+    });
+
   });
 
   describe('DELETE /:user', () => {

--- a/services/api/src/utils/__tests__/schema.test.js
+++ b/services/api/src/utils/__tests__/schema.test.js
@@ -875,6 +875,56 @@ describe('validation', () => {
       assertFail(schema, {});
     });
 
+    it('should not enforce a schema on unstructured objects', () => {
+      const User = createTestModel(
+        createSchema({
+          profile: {
+            name: 'String',
+          },
+          devices: [
+            {
+              type: 'Object',
+            },
+          ],
+        })
+      );
+      const schema = User.getUpdateValidation();
+      expect(Joi.isSchema(schema)).toBe(true);
+      assertPass(schema, {
+        devices: [
+          {
+            id: 'id',
+            name: 'name',
+            class: 'class',
+          },
+        ],
+      });
+      assertPass(schema, {
+        profile: {
+          name: 'foo',
+        },
+        devices: [
+          {
+            id: 'id',
+            name: 'name',
+            class: 'class',
+          },
+        ],
+      });
+      assertFail(schema, {
+        profile: {
+          foo: 'bar',
+        },
+        devices: [
+          {
+            id: 'id',
+            name: 'name',
+            class: 'class',
+          },
+        ],
+      });
+    });
+
     it('should strip reserved fields', () => {
       const User = createTestModel(
         createSchema({

--- a/services/api/src/utils/__tests__/validation.test.js
+++ b/services/api/src/utils/__tests__/validation.test.js
@@ -659,15 +659,22 @@ describe('getJoiSchema', () => {
       assertFail(schema, { counts: { view: 'bad number' } });
     });
 
-    it('should validate explicit mixed type', () => {
+    it('should not validate mixed type', () => {
+      const schema = getJoiSchema({
+        counts: 'Mixed'
+      });
+      assertPass(schema, { counts: { foo: 'bar' } });
+      assertPass(schema, { counts: { name: 'foo' } });
+    });
+
+    it('should not validate explicit mixed type', () => {
       const schema = getJoiSchema({
         counts: {
-          type: 'Mixed',
-          view: Number,
-        },
+          type: 'Mixed'
+        }
       });
-      assertPass(schema, { counts: { view: 1 } });
-      assertFail(schema, { counts: { view: 'bad number' } });
+      assertPass(schema, { counts: { foo: 'bar' } });
+      assertPass(schema, { counts: { name: 'foo' } });
     });
 
     it('should validate mixed with nested type object', () => {

--- a/services/api/src/utils/middleware/validate.js
+++ b/services/api/src/utils/middleware/validate.js
@@ -10,7 +10,7 @@ function validateBody(schema, options) {
   return (ctx, next) => {
     const { value, error } = validator(ctx.request.body);
     if (error) {
-      ctx.throw(400, error);
+      ctx.throw(getErrorCode(error), error);
     }
     ctx.request.body = value;
     return next();
@@ -22,7 +22,7 @@ function validateQuery(schema, options) {
   return (ctx, next) => {
     const { value, error } = validator(ctx.request.query);
     if (error) {
-      ctx.throw(400, error);
+      ctx.throw(getErrorCode(error), error);
     }
 
     // Koa (and the koa-qs module) uses a setter which causes the
@@ -78,6 +78,13 @@ function getValidator(schema, options = {}) {
     }
     return { value, error };
   };
+}
+
+function getErrorCode(error) {
+  const isPermissions = error.details.every((err) => {
+    return err.context.permissions;
+  });
+  return isPermissions ? 401 : 400;
 }
 
 module.exports = {

--- a/services/api/src/utils/schema.js
+++ b/services/api/src/utils/schema.js
@@ -113,10 +113,11 @@ function attributesToDefinition(attributes) {
   const isSchemaType = !!type && typeof type !== 'object';
 
   for (let [key, val] of Object.entries(attributes)) {
+    const type = typeof val;
     if (isSchemaType) {
-      if (key === 'type' && typeof val === 'string') {
+      if (key === 'type' && type === 'string') {
         val = getMongooseType(val);
-      } else if (key === 'validate' && typeof val === 'string') {
+      } else if (key === 'validate' && type === 'string') {
         // Allow custom mongoose validation function that derives from the Joi schema.
         val = getMongooseValidator(val, attributes);
       }
@@ -125,6 +126,8 @@ function attributesToDefinition(attributes) {
         val = val.map(attributesToDefinition);
       } else if (isPlainObject(val)) {
         val = attributesToDefinition(val);
+      } else if (type === 'string') {
+        val = getMongooseType(val);
       }
     }
     definition[key] = val;

--- a/services/api/src/utils/validation.js
+++ b/services/api/src/utils/validation.js
@@ -77,7 +77,7 @@ function getSchemaForField(field, options = {}) {
   const type = getFieldType(field);
   if (type === 'Array') {
     return getArraySchema(field, options);
-  } else if (type === 'Mixed') {
+  } else if (type === 'Object') {
     return getObjectSchema(field, options);
   }
 
@@ -99,18 +99,19 @@ function getSchemaForField(field, options = {}) {
     // db whatsoever?
     schema = schema.allow('', null);
   }
-
-  if (field.enum) {
-    schema = schema.valid(...field.enum);
-  }
-  if (field.match) {
-    schema = schema.pattern(RegExp(field.match));
-  }
-  if (field.min || field.minLength) {
-    schema = schema.min(field.min || field.minLength);
-  }
-  if (field.max || field.maxLength) {
-    schema = schema.max(field.max || field.maxLength);
+  if (typeof field === 'object') {
+    if (field.enum) {
+      schema = schema.valid(...field.enum);
+    }
+    if (field.match) {
+      schema = schema.pattern(RegExp(field.match));
+    }
+    if (field.min || field.minLength) {
+      schema = schema.min(field.min || field.minLength);
+    }
+    if (field.max || field.maxLength) {
+      schema = schema.max(field.max || field.maxLength);
+    }
   }
   return schema;
 }
@@ -149,6 +150,8 @@ function getSchemaForType(type) {
       return Joi.boolean();
     case 'Date':
       return Joi.date().iso();
+    case 'Mixed':
+      return Joi.object();
     case 'ObjectId':
       return Joi.custom((val) => {
         const id = String(val.id || val);
@@ -173,10 +176,10 @@ function getFieldType(field) {
     return field.schemaName || field.name;
   } else if (typeof field === 'object') {
     if (!field.type || typeof field.type === 'object') {
-      // Nested mixed type field
+      // Nested field
       // profile: { name: String } (no type field)
       // type: { type: 'String' } (may be nested)
-      return 'Mixed';
+      return 'Object';
     } else {
       // name: { type: String }
       // name: { type: 'String' }


### PR DESCRIPTION
1. Changes `access: 'private'` to `readScopes: 'none' | 'all' | [<string>]` ... this aligns with the new `writeScopes`. This will allow to entirely disable or conditionally disable serialization of certain fields. Calling `doc.toObject({ scopes: ['admin'] })` will output any field marked `readScopes: ['admin']`. This dovetails with our recent org permissions updates so it's easy to do something like `doc.toObject({ scopes: authUser.roles })` but still maintain separation there. Keep in mind that going forward "writeScopes" simply affects the new Joi validations and "readScopes" only affects object serialization... Once you're in mongoose land (inside the controller) you can still update or access any field.

2. Fix for allowing "Mixed" schema type of unstructured JSON.