### PR TITLE
Soft delete performance tweaks

### DIFF
--- a/services/api/src/routes/invites.js
+++ b/services/api/src/routes/invites.js
@@ -64,7 +64,7 @@ router
             email,
             status: 'invited',
           },
-          { status: 'invited', email, $unset: { deletedAt: 1 } },
+          { status: 'invited', email, $unset: { deleted: 1, deletedAt: 1 } },
           {
             new: true,
             upsert: true,


### PR DESCRIPTION
We benchmarked the `deletedAt: {$exists: false}` query to be 10x slower on count queries VS a simple boolean match. This PR fixes this