### PR TITLE
filters modal improvements

### DIFF
--- a/services/web/src/modals/Filters/index.js
+++ b/services/web/src/modals/Filters/index.js
@@ -19,12 +19,16 @@ export default class Filters extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      ...props.filters,
+      modalOpen: false,
+      filters: {
+        ...props.filters,
+      },
     };
     this.formRef = React.createRef();
   }
 
   onModalOpen = () => {
+    this.setState({ modalOpen: true, filters: this.props.filters });
     setTimeout(() => {
       const input = this.formRef.current.querySelector('input[name]');
       input?.focus();
@@ -36,18 +40,27 @@ export default class Filters extends React.Component {
   };
 
   onSubmit = () => {
-    this.props.onSave(this.state);
+    this.setState({
+      modalOpen: false,
+    });
+    this.props.onSave(this.state.filters);
   };
 
   onReset = () => {
-    const state = {};
-    this.setState(state);
-    this.props.onSave(state);
+    const filters = {};
+    this.setState({
+      filters,
+      modalOpen: false,
+    });
+    this.props.onSave(filters);
   };
 
   setFilter(name, value) {
     this.setState({
-      [name]: value,
+      filters: {
+        ...this.state.filters,
+        [name]: value,
+      },
     });
   }
 
@@ -58,11 +71,15 @@ export default class Filters extends React.Component {
 
   render() {
     const { size } = this.props;
+    const { modalOpen } = this.state;
+
     return (
       <Modal
         closeIcon
         size="tiny"
+        onClose={() => this.setState({ modalOpen: false })}
         onOpen={this.onModalOpen}
+        open={modalOpen}
         trigger={
           this.hasFilters() ? (
             <Button as="div" labelPosition="right">
@@ -71,7 +88,7 @@ export default class Filters extends React.Component {
                 Filter
               </Button>
               <Label as="a" pointing="left">
-                {Object.keys(this.props.filters).length}
+                Enabled
               </Label>
             </Button>
           ) : (
@@ -99,7 +116,7 @@ export default class Filters extends React.Component {
   }
 
   renderDateFilters() {
-    const { startAt, endAt } = this.state;
+    const { startAt, endAt } = this.state.filters;
     return (
       <Form.Field>
         <label>Created At</label>
@@ -138,7 +155,7 @@ export default class Filters extends React.Component {
     return React.Children.map(this.props.children, (filter) => {
       const { name, multiple } = filter.props;
       return React.cloneElement(filter, {
-        value: this.state[name] || (multiple ? [] : ''),
+        value: this.state.filters[name] || (multiple ? [] : ''),
         onChange: this.onFilterChange,
       });
     });


### PR DESCRIPTION
- Trigger close dialog on apply + reset
- replaces `Object.keys(this.props.filters).length` with `Enabled` string because the count is not correct with date filters as it exposes 2 fields (startAt + endAt)
- Ensure that filters that have not been applied are not saved, when closing the dialog

### Other issues still left but perhaps needs some thinking

Using the Filters.Checkbox and checking one => triggers the filters to enabled. But unchecking the Filters.Checkbox also triggers it because the check is simple like and the value of an unchecked Checkbox is false.

```
  hasFilters() {
    const { filters } = this.props;
    return filters && Object.keys(filters).length > 0;
  }
```

The hasFilters doesn't really work. 

Besides sometimes you would like to have a Search field outside the dialog or other filters outside of the control of Filters dialog ... those "outside" filters can also interfere with the hasFilters.


### Second wish is to allow more control of the UI.
E.g. would like to able to this ... perhaps Context could be used ... might be other solutions.

```
 <Filters
            onSave={(newFilters) =>
              setFilters({ searchId: filters.searchId, ...newFilters })
            }
                  filters={filters}>
                 <Grid>
                  <Grid.Column>
                  <Filters.Checkbox
                    name="showUnInvoiced"
                    label={t(
                      'sessionsFilter.uninvoicedOnly',
                      'Uninvoiced Only'
                    )}
                  />
                  <Filters.Checkbox
                    name="excluded"
                    label={t(
                      'sessionsFilter.excluded',
                      'Excluded From Billing'
                    )}
                  />
               </Grid.Column>
                <Grid.Column>
                  <Filters.Checkbox
                    name="hasErrors"
                    label={t('sessionsFilter.hasErrors', 'Has Sync Errors')}
                  />
                 <Grid.Column>

```

### Allow Some filters to be visible outside the dialog ?
To have a certain fields visible both in the dialog or rendered directly in the UI ... could also be nice.
