### PR TITLE
prefixed the jwt localstorage key, with APP_NAME

### DIFF
--- a/services/web/src/utils/api/token.js
+++ b/services/web/src/utils/api/token.js
@@ -1,4 +1,7 @@
-const KEY = 'jwt';
+import { APP_NAME } from 'utils/env';
+import { camelCase } from 'lodash';
+
+const KEY = `${camelCase(APP_NAME)}JWT`;
 
 export function hasToken() {
   return !!getToken();

--- a/services/web/src/utils/api/token.js
+++ b/services/web/src/utils/api/token.js
@@ -1,7 +1,7 @@
 import { APP_NAME } from 'utils/env';
-import { camelCase } from 'lodash';
+import { snakeCase } from 'lodash';
 
-const KEY = `${camelCase(APP_NAME)}JWT`;
+const KEY = `${snakeCase(APP_NAME)}_jwt`;
 
 export function hasToken() {
   return !!getToken();


### PR DESCRIPTION
Just a little optimization, but let me know if you have any concern. 

I just noticed when switching between projects, that keep finding myself logged out ... because i use the same domain e.g. localhost:2200. for each project. The jwt token keep being overwritten (correctly so)

This just prefix the localstorage key for the jwt token with the APP_NAME allow you to easy switch between projects.



