### PR TITLE
allowing nested keys

### DIFF
--- a/services/api/src/utils/schema.js
+++ b/services/api/src/utils/schema.js
@@ -471,6 +471,7 @@ function flattenQuery(query, schema, root = {}, rootPath = []) {
   for (let [key, value] of Object.entries(query)) {
     if (key.includes('.')) {
       // Custom dot syntax is allowed and is already flattened, so skip.
+      root[key] = value;
       continue;
     }
     const path = [...rootPath, key];


### PR DESCRIPTION
This allows:

```
Schema.search({
   "nested.field": "search"
})
```

As well as naturally

```
Schema.search({
   "nested": {
     "field":   "search"
  }
})
```


