### PR TITLE
Feature/auth tweaks attempts

### DIFF
--- a/services/api/src/models/user.js
+++ b/services/api/src/models/user.js
@@ -6,10 +6,10 @@ const { validScopes } = require('../utils/permissions');
 const definition = require('./definitions/user.json');
 
 const LOGIN_THROTTLE = {
-  // Apply lockout after 3 tries
-  triesMin: 3,
+  // Apply lockout after 5 tries
+  triesMin: 5,
   // Scale to max at 10 tries
-  triesMax: 10,
+  triesMax: 12,
   // 1 hour lockout maximum
   timeMax: 60 * 60 * 1000,
 };

--- a/services/api/src/models/user.js
+++ b/services/api/src/models/user.js
@@ -28,7 +28,10 @@ schema.method('verifyLoginAttempts', function verifyLoginAttempts() {
   const { triesMin, triesMax, timeMax } = LOGIN_THROTTLE;
   const dt = new Date() - this.lastLoginAttemptAt || Date.now();
   const threshold = mapExponential(this.loginAttempts, triesMin, triesMax, 0, timeMax);
-  return dt >= threshold;
+  return {
+    verified: dt >= threshold,
+    threshold,
+  };
 });
 
 schema.virtual('name').get(function () {

--- a/services/api/src/models/user.js
+++ b/services/api/src/models/user.js
@@ -1,38 +1,12 @@
 const mongoose = require('mongoose');
 const bcrypt = require('bcrypt');
-const { mapExponential } = require('../utils/math');
+
 const { createSchema } = require('../utils/schema');
 const { validScopes } = require('../utils/permissions');
 const definition = require('./definitions/user.json');
 
-const LOGIN_THROTTLE = {
-  // Apply lockout after 5 tries
-  triesMin: 5,
-  // Scale to max at 10 tries
-  triesMax: 12,
-  // 1 hour lockout maximum
-  timeMax: 60 * 60 * 1000,
-};
-
 definition.attributes.roles[0].scope.enum = validScopes;
 const schema = createSchema(definition);
-
-schema.method('verifyPassword', async function verifyPassword(password) {
-  if (!this.hashedPassword) {
-    throw Error('No password set for user');
-  }
-  return bcrypt.compare(password, this.hashedPassword);
-});
-
-schema.method('verifyLoginAttempts', function verifyLoginAttempts() {
-  const { triesMin, triesMax, timeMax } = LOGIN_THROTTLE;
-  const dt = new Date() - this.lastLoginAttemptAt || Date.now();
-  const threshold = mapExponential(this.loginAttempts, triesMin, triesMax, 0, timeMax);
-  return {
-    verified: dt >= threshold,
-    threshold,
-  };
-});
 
 schema.virtual('name').get(function () {
   return [this.firstName, this.lastName].join(' ');

--- a/services/api/src/routes/__tests__/auth.js
+++ b/services/api/src/routes/__tests__/auth.js
@@ -178,7 +178,7 @@ describe('/1/auth', () => {
       });
       let response = await request('POST', '/1/auth/confirm-access', { password: 'bad password' }, { user });
       expect(response.status).toBe(401);
-      expect(response.body.error.message).toBe('Too many attempts');
+      expect(response.body.error.message).toBe('Too many attempts. Try again in 15 minute(s)');
     });
   });
 

--- a/services/api/src/routes/__tests__/auth.js
+++ b/services/api/src/routes/__tests__/auth.js
@@ -3,6 +3,7 @@ const { createTemporaryToken, generateTokenId } = require('../../utils/tokens');
 const { setupDb, teardownDb, request, createUser } = require('../../utils/testing');
 const { mockTime, unmockTime, advanceTime } = require('../../utils/testing/time');
 const { User, Invite } = require('../../models');
+const { verifyPassword } = require('../../utils/auth');
 
 beforeAll(async () => {
   await setupDb();
@@ -52,7 +53,7 @@ describe('/1/auth', () => {
       });
       let response;
 
-      await request('POST', '/1/auth/login', { email: user.email, password: 'bad password' });
+      response = await request('POST', '/1/auth/login', { email: user.email, password: 'bad password' });
 
       response = await request('POST', '/1/auth/login', { email: user.email, password });
       expect(response.status).toBe(401);
@@ -282,7 +283,7 @@ describe('/1/auth', () => {
 
       const updatedUser = await User.findById(user.id);
       await expect(async () => {
-        await updatedUser.verifyPassword(password);
+        await verifyPassword(updatedUser, password);
       }).not.toThrow();
     });
 

--- a/services/api/src/routes/__tests__/auth.js
+++ b/services/api/src/routes/__tests__/auth.js
@@ -41,13 +41,13 @@ describe('/1/auth', () => {
       expect(payload).toHaveProperty('type', 'mfa');
     });
 
-    it('should throttle a few seconds after 3 bad attempts', async () => {
+    it('should throttle a few seconds after 5 bad attempts', async () => {
       mockTime();
 
       const password = '123password!';
       const user = await createUser({
         password,
-        loginAttempts: 3,
+        loginAttempts: 5,
         lastLoginAttemptAt: new Date(),
       });
       let response;

--- a/services/api/src/routes/__tests__/mfa.js
+++ b/services/api/src/routes/__tests__/mfa.js
@@ -122,7 +122,7 @@ describe('/1/mfa', () => {
         { headers: { Authorization: `Bearer ${token}` } }
       );
       expect(response.status).toBe(401);
-      expect(response.body.error.message).toBe('Too many attempts');
+      expect(response.body.error.message).toBe('Too many attempts. Try again in 15 minute(s)');
     });
   });
 

--- a/services/api/src/routes/auth.js
+++ b/services/api/src/routes/auth.js
@@ -84,7 +84,7 @@ router
           object: user,
           user: user.id,
         });
-        ctx.throw(400, error);
+        ctx.throw(401, error);
       }
 
       if (await mfa.requireChallenge(ctx, user)) {
@@ -145,7 +145,7 @@ router
           object: authUser,
           user: authUser.id,
         });
-        ctx.throw(400, error);
+        ctx.throw(401, error);
       }
 
       await AuditEntry.append('successfully authenticated (confirm-access)', ctx, {

--- a/services/api/src/routes/mfa.js
+++ b/services/api/src/routes/mfa.js
@@ -50,7 +50,7 @@ router
       const { jwt } = ctx.state;
       const { code } = ctx.request.body;
 
-      const user = await User.findOneAndUpdate({ _id: jwt.sub });
+      const user = await User.findOne({ _id: jwt.sub });
 
       if (!user) {
         ctx.throw(400, 'User does not exist');

--- a/services/api/src/routes/mfa.js
+++ b/services/api/src/routes/mfa.js
@@ -50,13 +50,7 @@ router
       const { jwt } = ctx.state;
       const { code } = ctx.request.body;
 
-      const user = await User.findOneAndUpdate(
-        { _id: jwt.sub },
-        {
-          lastLoginAttemptAt: new Date(),
-          $inc: { loginAttempts: 1 },
-        }
-      );
+      const user = await User.findOneAndUpdate({ _id: jwt.sub });
 
       if (!user) {
         ctx.throw(400, 'User does not exist');
@@ -73,6 +67,12 @@ router
         });
         ctx.throw(401, `Too many attempts. Try again in ${Math.max(1, Math.floor(threshold / (60 * 1000)))} minute(s)`);
       }
+
+      user.set({
+        lastLoginAttemptAt: new Date(),
+        loginAttempts: user.loginAttempts + 1,
+      });
+      await user.save();
 
       // if backup code e.g 12345-16123
       const backupCodes = (user.mfaBackupCodes || []).concat();

--- a/services/api/src/routes/mfa.js
+++ b/services/api/src/routes/mfa.js
@@ -64,13 +64,14 @@ router
         ctx.throw(400, 'Token is invalid (jti)');
       }
 
-      if (!user.verifyLoginAttempts()) {
+      const { verified, threshold } = user.verifyLoginAttempts();
+      if (!verified) {
         await AuditEntry.append('reached max mfa challenge attempts', ctx, {
           type: 'security',
           object: user,
           user: user.id,
         });
-        ctx.throw(401, 'Too many attempts');
+        ctx.throw(401, `Too many attempts. Try again in ${Math.max(1, Math.floor(threshold / (60 * 1000)))} minute(s)`);
       }
 
       // if backup code e.g 12345-16123

--- a/services/api/src/utils/auth.js
+++ b/services/api/src/utils/auth.js
@@ -13,7 +13,7 @@ const LOGIN_THROTTLE = {
 async function verifyLoginAttempts(user) {
   const { triesMin, triesMax, timeMax } = LOGIN_THROTTLE;
   const dt = new Date() - user.lastLoginAttemptAt || Date.now();
-  const threshold = mapExponential(user.loginAttempts, triesMin, triesMax, 0, timeMax);
+  const threshold = mapExponential(user.loginAttempts || 0, triesMin, triesMax, 0, timeMax);
 
   if (dt >= threshold) {
     user.set({

--- a/services/api/src/utils/auth.js
+++ b/services/api/src/utils/auth.js
@@ -1,0 +1,46 @@
+const { mapExponential } = require('../utils/math');
+const bcrypt = require('bcrypt');
+
+const LOGIN_THROTTLE = {
+  // Apply lockout after 5 tries
+  triesMin: 5,
+  // Scale to max at 10 tries
+  triesMax: 12,
+  // 1 hour lockout maximum
+  timeMax: 60 * 60 * 1000,
+};
+
+async function verifyLoginAttempts(user) {
+  const { triesMin, triesMax, timeMax } = LOGIN_THROTTLE;
+  const dt = new Date() - user.lastLoginAttemptAt || Date.now();
+  const threshold = mapExponential(user.loginAttempts, triesMin, triesMax, 0, timeMax);
+
+  if (dt >= threshold) {
+    user.set({
+      lastLoginAttemptAt: new Date(),
+      loginAttempts: user.loginAttempts + 1,
+    });
+    await user.save();
+    return;
+  }
+
+  throw Error(`Too many attempts. Try again in ${Math.max(1, Math.floor(threshold / (60 * 1000)))} minute(s)`);
+}
+
+async function verifyPassword(user, password) {
+  if (!user.hashedPassword) {
+    throw Error('No password sets');
+  }
+
+  if (!(await bcrypt.compare(password, user.hashedPassword))) {
+    throw Error('Incorrect password');
+  }
+
+  user.loginAttempts = 0;
+  await user.save();
+}
+
+module.exports = {
+  verifyLoginAttempts,
+  verifyPassword,
+};

--- a/services/api/src/utils/mfa.js
+++ b/services/api/src/utils/mfa.js
@@ -10,11 +10,6 @@ async function requireChallenge(ctx, user) {
 }
 
 function generateSecret(options) {
-  const config = {
-    name: encodeURIComponent(options?.name ?? 'App').toLowerCase(),
-    account: encodeURIComponent(options?.account ? `:${options.account}` : '').toLowerCase(),
-  };
-
   const bin = crypto.randomBytes(20);
   const base32 = b32.encode(bin).toString('utf8').replace(/=/g, '');
 

--- a/services/api/src/utils/mfa.js
+++ b/services/api/src/utils/mfa.js
@@ -9,7 +9,7 @@ async function requireChallenge(ctx, user) {
   return false;
 }
 
-function generateSecret(options) {
+function generateSecret() {
   const bin = crypto.randomBytes(20);
   const base32 = b32.encode(bin).toString('utf8').replace(/=/g, '');
 


### PR DESCRIPTION
- Improved the error message to indicate when you can retry again
- I have increased the attempts a tiny bit, just to remove friction.
- If a user is blocked from authenticating, the api should not attempt to increase login attempts, as long as the user cannot reauthenticate.
- On the mfa endpoints the LOGIN_THROTTLE was not being applied correctly
