### PR TITLE
validate objectId

### DIFF
--- a/services/api/src/routes/invites.js
+++ b/services/api/src/routes/invites.js
@@ -1,3 +1,4 @@
+const mongoose = require('mongoose');
 const Router = require('@koa/router');
 const Joi = require('joi');
 const { validateBody } = require('../utils/middleware/validate');
@@ -26,12 +27,14 @@ function sendInvite(sender, invite) {
 
 router
   .param('inviteId', async (id, ctx, next) => {
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      ctx.throw(400, 'ObjectId in path is not valid');
+    }
     const invite = await Invite.findById(id);
-    ctx.state.invite = invite;
-
     if (!invite) {
       ctx.throw(404);
     }
+    ctx.state.invite = invite;
 
     return next();
   })

--- a/services/api/src/routes/invites.js
+++ b/services/api/src/routes/invites.js
@@ -28,7 +28,7 @@ function sendInvite(sender, invite) {
 router
   .param('inviteId', async (id, ctx, next) => {
     if (!mongoose.Types.ObjectId.isValid(id)) {
-      ctx.throw(400, 'ObjectId in path is not valid');
+      ctx.throw(404);
     }
     const invite = await Invite.findById(id);
     if (!invite) {

--- a/services/api/src/routes/organizations.js
+++ b/services/api/src/routes/organizations.js
@@ -1,3 +1,4 @@
+const mongoose = require('mongoose');
 const Router = require('@koa/router');
 const { validateBody } = require('../utils/middleware/validate');
 const { authenticate, fetchUser } = require('../utils/middleware/authenticate');
@@ -10,6 +11,9 @@ router
   .use(authenticate({ type: 'user' }))
   .use(fetchUser)
   .param('organizationId', async (id, ctx, next) => {
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      ctx.throw(400, 'ObjectId in path is not valid');
+    }
     const organization = await Organization.findById(id);
     ctx.state.organization = organization;
     if (!organization) {

--- a/services/api/src/routes/organizations.js
+++ b/services/api/src/routes/organizations.js
@@ -12,7 +12,7 @@ router
   .use(fetchUser)
   .param('organizationId', async (id, ctx, next) => {
     if (!mongoose.Types.ObjectId.isValid(id)) {
-      ctx.throw(400, 'ObjectId in path is not valid');
+      ctx.throw(404);
     }
     const organization = await Organization.findById(id);
     ctx.state.organization = organization;

--- a/services/api/src/routes/products.js
+++ b/services/api/src/routes/products.js
@@ -12,7 +12,7 @@ router
   .use(fetchUser)
   .param('productId', async (id, ctx, next) => {
     if (!mongoose.Types.ObjectId.isValid(id)) {
-      ctx.throw(400, 'ObjectId in path is not valid');
+      ctx.throw(404);
     }
     const product = await Product.findById(id);
     if (!product) {

--- a/services/api/src/routes/shops.js
+++ b/services/api/src/routes/shops.js
@@ -1,3 +1,4 @@
+const mongoose = require('mongoose');
 const Router = require('@koa/router');
 const { validateBody } = require('../utils/middleware/validate');
 const { authenticate, fetchUser } = require('../utils/middleware/authenticate');
@@ -9,16 +10,15 @@ router
   .use(authenticate({ type: 'user' }))
   .use(fetchUser)
   .param('shopId', async (id, ctx, next) => {
-    try {
-      const shop = await Shop.findById(id);
-      if (!shop) {
-        ctx.throw(404);
-      }
-      ctx.state.shop = shop;
-      return next();
-    } catch (err) {
-      ctx.throw(400, err);
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      ctx.throw(400, 'ObjectId in path is not valid');
     }
+    const shop = await Shop.findById(id);
+    if (!shop) {
+      ctx.throw(404);
+    }
+    ctx.state.shop = shop;
+    return next();
   })
   .post('/', validateBody(Shop.getCreateValidation()), async (ctx) => {
     const shop = await Shop.create(ctx.request.body);

--- a/services/api/src/routes/shops.js
+++ b/services/api/src/routes/shops.js
@@ -11,7 +11,7 @@ router
   .use(fetchUser)
   .param('shopId', async (id, ctx, next) => {
     if (!mongoose.Types.ObjectId.isValid(id)) {
-      ctx.throw(400, 'ObjectId in path is not valid');
+      ctx.throw(404, 'ObjectId in path is not valid');
     }
     const shop = await Shop.findById(id);
     if (!shop) {

--- a/services/api/src/routes/uploads.js
+++ b/services/api/src/routes/uploads.js
@@ -10,7 +10,7 @@ const router = new Router();
 router
   .param('uploadId', async (id, ctx, next) => {
     if (!mongoose.Types.ObjectId.isValid(id)) {
-      ctx.throw(400, 'ObjectId in path is not valid');
+      ctx.throw(404);
     }
     const upload = await Upload.findById(id);
     if (!upload) {

--- a/services/api/src/routes/uploads.js
+++ b/services/api/src/routes/uploads.js
@@ -1,3 +1,4 @@
+const mongoose = require('mongoose');
 const Router = require('@koa/router');
 const { createReadStream } = require('fs');
 const { authenticate, fetchUser } = require('../utils/middleware/authenticate');
@@ -8,18 +9,17 @@ const router = new Router();
 
 router
   .param('uploadId', async (id, ctx, next) => {
-    try {
-      const upload = await Upload.findById(id);
-      if (!upload) {
-        ctx.throw(404);
-      } else if (ctx.state.authUser.id != upload.owner) {
-        ctx.throw(401);
-      }
-      ctx.state.upload = upload;
-      return next();
-    } catch (err) {
-      ctx.throw(400, err);
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      ctx.throw(400, 'ObjectId in path is not valid');
     }
+    const upload = await Upload.findById(id);
+    if (!upload) {
+      ctx.throw(404);
+    } else if (ctx.state.authUser.id != upload.owner) {
+      ctx.throw(401);
+    }
+    ctx.state.upload = upload;
+    return next();
   })
   .get('/:id', async (ctx) => {
     const upload = await Upload.findById(ctx.params.id);

--- a/services/api/src/routes/users.js
+++ b/services/api/src/routes/users.js
@@ -21,7 +21,7 @@ router
   .use(fetchUser)
   .param('userId', async (id, ctx, next) => {
     if (!mongoose.Types.ObjectId.isValid(id)) {
-      ctx.throw(400, 'ObjectId in path is not valid');
+      ctx.throw(404);
     }
     const user = await User.findById(id);
     if (!user) {

--- a/services/api/src/routes/users.js
+++ b/services/api/src/routes/users.js
@@ -1,5 +1,6 @@
 const Router = require('@koa/router');
 const Joi = require('joi');
+const mongoose = require('mongoose');
 const { validateBody } = require('../utils/middleware/validate');
 const { authenticate, fetchUser } = require('../utils/middleware/authenticate');
 const { requirePermissions } = require('../utils/middleware/permissions');
@@ -19,16 +20,15 @@ router
   .use(authenticate({ type: 'user' }))
   .use(fetchUser)
   .param('userId', async (id, ctx, next) => {
-    try {
-      const user = await User.findById(id);
-      if (!user) {
-        ctx.throw(404);
-      }
-      ctx.state.user = user;
-      return next();
-    } catch (err) {
-      ctx.throw(400, err);
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      ctx.throw(400, 'ObjectId in path is not valid');
     }
+    const user = await User.findById(id);
+    if (!user) {
+      ctx.throw(404);
+    }
+    ctx.state.user = user;
+    return next();
   })
   .get('/me', (ctx) => {
     const { authUser } = ctx.state;


### PR DESCRIPTION
Cleared up the "wide" try and catch, and added a check to validate for bad ObjectId

I was considering trying to make a param middleware e.g. 

 `.param('inviteId',  validateObjectId,async (id, ctx, next) => {`

but i couldn't make that work, I dont think its supported, by the router.