### PR TITLE
Remove fixture loading on cli entrypoint

### DIFF
--- a/services/api/scripts/entrypoints/cli.sh
+++ b/services/api/scripts/entrypoints/cli.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 echo "" > /service/crontab.log
-./scripts/fixtures/load
 echo "" > /service/.motd
 echo "Welcome to the API CLI pod. All API code is available here." >> /service/.motd
 echo "" >> /service/.motd


### PR DESCRIPTION
This doesn't look intentional considering it's one of the commands echoed out. Just had a bunch of fixtures imported in prod after loading up the cli and I suspect this was the source.