### PR TITLE
Feature/brc 32 add a crud view for audit trail

### DIFF
--- a/services/api/src/models/__tests__/audit-entry.js
+++ b/services/api/src/models/__tests__/audit-entry.js
@@ -112,7 +112,9 @@ describe('AuditEntry', () => {
 
   describe('append', () => {
     it('should write to the db', async () => {
-      const user = new User({ email: 'bob@gmail.com' });
+      const user = await createUser({
+        email: 'audit@log.com',
+      });
       const ctx = await getContext(user);
 
       await AuditEntry.append('did something', ctx, {
@@ -125,7 +127,7 @@ describe('AuditEntry', () => {
       expect(logs.length).toBe(1);
 
       const log = logs[0];
-      expect(log.type).toBe('security');
+      expect(log.category).toBe('security');
       expect(log.activity).toBe('did something');
       expect(log.objectId.toString()).toBe(user.id);
       expect(log.objectType).toBe('user');
@@ -133,7 +135,7 @@ describe('AuditEntry', () => {
       expect(log.requestUrl).toBe('/1/products/id');
       expect(log.routeNormalizedPath).toBe('/1/products/:id');
       expect(log.createdAt).toBeDefined();
-      expect(log.user.toString()).toBe(user.id);
+      expect(log.user.id).toBe(user.id);
     });
 
     it('should not change, if nothing was changed', async () => {

--- a/services/api/src/models/__tests__/audit-entry.js
+++ b/services/api/src/models/__tests__/audit-entry.js
@@ -117,7 +117,7 @@ describe('AuditEntry', () => {
       const ctx = await getContext(user);
 
       await AuditEntry.append('did something', ctx, {
-        type: 'security',
+        category: 'security',
         objectId: user.id,
         objectType: 'user',
       });
@@ -142,7 +142,7 @@ describe('AuditEntry', () => {
       const ctx = await getContext(user);
 
       await AuditEntry.append('did something', ctx, {
-        type: 'security',
+        category: 'security',
         objectId: user.id,
         objectType: 'user',
         objectAfter: {},

--- a/services/api/src/models/__tests__/audit-entry.js
+++ b/services/api/src/models/__tests__/audit-entry.js
@@ -104,7 +104,6 @@ describe('AuditEntry', () => {
           requestMethod: 'GET',
           requestUrl: '/1/products/id',
           routeNormalizedPath: '/1/products/:id',
-          routePrefix: '/1/products',
           user: user.id,
         })
       );

--- a/services/api/src/models/audit-entry.js
+++ b/services/api/src/models/audit-entry.js
@@ -63,6 +63,7 @@ schema.statics.append = function (activity, ctx, { object, fields, category, ...
     return;
   }
 
+  console.log('options.user || fromContext.user', options.user || fromContext.user);
   return this.create({
     ...fromContext,
     activity,
@@ -75,6 +76,6 @@ schema.statics.append = function (activity, ctx, { object, fields, category, ...
   });
 };
 
-schema.index({  category: 1, objectType: 1, createdAt: 1, activity: 1, routeNormalizedPath: 1 });
+schema.index({ category: 1, objectType: 1, createdAt: 1, activity: 1, routeNormalizedPath: 1 });
 
 module.exports = mongoose.models.AuditEntry || mongoose.model('AuditEntry', schema);

--- a/services/api/src/models/audit-entry.js
+++ b/services/api/src/models/audit-entry.js
@@ -52,7 +52,7 @@ schema.statics.getObjectFields = function getObjectFields(object, fields = []) {
   return objectFields;
 };
 
-schema.statics.append = function (activity, ctx, { object, fields, type, ...options }) {
+schema.statics.append = function (activity, ctx, { object, fields, category, ...options }) {
   const fromContext = this.getContextFields(ctx);
 
   if (object) {
@@ -71,9 +71,11 @@ schema.statics.append = function (activity, ctx, { object, fields, type, ...opti
     objectType: options.objectType,
     objectBefore: options.objectBefore,
     objectAfter: options.objectAfter,
-    type,
+    category,
     user: options.user || fromContext.user,
   });
 };
+
+schema.index({  category: 1, objectType: 1, createdAt: 1, activity: 1, routeNormalizedPath: 1 });
 
 module.exports = mongoose.models.AuditEntry || mongoose.model('AuditEntry', schema);

--- a/services/api/src/models/audit-entry.js
+++ b/services/api/src/models/audit-entry.js
@@ -12,7 +12,6 @@ schema.statics.getContextFields = function (ctx) {
     requestMethod: ctx.request.method,
     requestUrl: ctx.request.url,
     routeNormalizedPath: ctx.routerPath,
-    routePrefix: ctx.router.opts.prefix,
   };
 };
 

--- a/services/api/src/models/definitions/application-request.json
+++ b/services/api/src/models/definitions/application-request.json
@@ -8,9 +8,6 @@
     "routeNormalizedPath": {
       "type": "String"
     },
-    "routePrefix": {
-      "type": "String"
-    },
     "requestId": {
       "type": "String"
     },

--- a/services/api/src/models/definitions/audit-entry.json
+++ b/services/api/src/models/definitions/audit-entry.json
@@ -8,9 +8,6 @@
       "type": "String",
       "required": true
     },
-    "routePrefix": {
-      "type": "String"
-    },
     "routeNormalizedPath": {
       "type": "String"
     },

--- a/services/api/src/models/definitions/audit-entry.json
+++ b/services/api/src/models/definitions/audit-entry.json
@@ -30,13 +30,18 @@
     "objectType": {
       "type": "String"
     },
-    "type": {
-      "type": "String"
+    "category": {
+      "type": "String",
+      "default": "default"
     },
     "user": {
       "type": "ObjectId",
       "ref": "User",
-      "required": true
+      "required": true,
+      "autopopulate": true
     }
-  }
+  },
+  "search": [
+    "objectId"
+  ]
 }

--- a/services/api/src/routes/audit-entries.js
+++ b/services/api/src/routes/audit-entries.js
@@ -1,4 +1,5 @@
 const Router = require('@koa/router');
+const Joi = require('joi');
 
 const { validateBody } = require('../utils/middleware/validate');
 const { authenticate, fetchUser } = require('../utils/middleware/authenticate');
@@ -29,6 +30,20 @@ router
         meta,
       };
     }
-  );
+  )
+  .post(
+    '/search-options',
+    validateBody({
+      field: Joi.string().allow("routeNormalizedPath", "objectType", "activity", "category").required()
+    }),
+    async (ctx) => {
+      const values = await AuditEntry.distinct(ctx.request.body.field);
+
+      ctx.body = {
+        data: values,
+      };
+    }
+  )
+
 
 module.exports = router;

--- a/services/api/src/routes/auth.js
+++ b/services/api/src/routes/auth.js
@@ -38,7 +38,7 @@ router
         ...ctx.request.body,
       });
 
-      await AuditEntry.append('registered', ctx, {
+      await AuditEntry.append('Registered', ctx, {
         object: user,
         user: user.id,
       });
@@ -71,8 +71,8 @@ router
       try {
         await verifyLoginAttempts(user);
       } catch (error) {
-        await AuditEntry.append('reached max authentication attempts', ctx, {
-          type: 'security',
+        await AuditEntry.append('Reached max authentication attempts', ctx, {
+          category: 'security',
           object: user,
           user: user.id,
         });
@@ -82,8 +82,8 @@ router
       try {
         await verifyPassword(user, password);
       } catch (error) {
-        await AuditEntry.append('failed authentication', ctx, {
-          type: 'security',
+        await AuditEntry.append('Failed authentication', ctx, {
+          category: 'security',
           object: user,
           user: user.id,
         });
@@ -110,7 +110,7 @@ router
       user.authTokenId = authTokenId;
       await user.save();
 
-      await AuditEntry.append('successfully authenticated', ctx, {
+      await AuditEntry.append('Successfully authenticated', ctx, {
         object: user,
         user: user.id,
       });
@@ -135,7 +135,7 @@ router
         await verifyLoginAttempts(authUser);
       } catch (error) {
         await AuditEntry.append('Reached max authentication attempts', ctx, {
-          type: 'security',
+          category: 'security',
           object: authUser,
           user: authUser.id,
         });
@@ -146,14 +146,14 @@ router
         await verifyPassword(authUser, password);
       } catch (error) {
         await AuditEntry.append('Failed authentication (confirm-access)', ctx, {
-          type: 'security',
+          category: 'security',
           object: authUser,
           user: authUser.id,
         });
         ctx.throw(401, error);
       }
 
-      await AuditEntry.append('successfully authenticated (confirm-access)', ctx, {
+      await AuditEntry.append('Successfully authenticated (confirm-access)', ctx, {
         object: authUser,
         user: authUser.id,
       });
@@ -165,6 +165,12 @@ router
   )
   .post('/logout', authenticate({ type: 'user' }), fetchUser, async (ctx) => {
     const user = ctx.state.authUser;
+
+    await AuditEntry.append('Deauthentication', ctx, {
+      object: user,
+      user: user.id,
+    });
+
     await user.updateOne({
       $unset: {
         authTokenId: true,
@@ -207,7 +213,7 @@ router
         authTokenId,
       });
 
-      await AuditEntry.append('registered', ctx, {
+      await AuditEntry.append('Registered', ctx, {
         object: user,
         user: user.id,
       });
@@ -256,8 +262,8 @@ router
       if (!user) {
         ctx.throw(400, 'User does not exist');
       } else if (user.tempTokenId !== jwt.jti) {
-        await AuditEntry.append('attempted reset password', ctx, {
-          type: 'security',
+        await AuditEntry.append('Attempted reset password', ctx, {
+          category: 'security',
           object: user,
           user: user.id,
         });
@@ -270,7 +276,7 @@ router
 
       await user.save();
 
-      await AuditEntry.append('reset password', ctx, {
+      await AuditEntry.append('Reset password', ctx, {
         object: user,
         user: user.id,
       });

--- a/services/api/src/routes/mfa.js
+++ b/services/api/src/routes/mfa.js
@@ -62,8 +62,8 @@ router
       try {
         await verifyLoginAttempts(user);
       } catch (error) {
-        await AuditEntry.append('reached max mfa challenge attempts', ctx, {
-          type: 'security',
+        await AuditEntry.append('Reached max mfa challenge attempts', ctx, {
+          category: 'security',
           object: user,
           user: user.id,
         });
@@ -78,20 +78,20 @@ router
         backupCodes.splice(foundBackupCode, 1);
         user.mfaBackupCodes = backupCodes;
         await user.save();
-        await AuditEntry.append('successfully authenticated (mfa using backup code)', ctx, {
+        await AuditEntry.append('Successfully authenticated (mfa using backup code)', ctx, {
           object: user,
           user: user.id,
         });
       } else if (!mfa.verifyToken(user.mfaSecret, user.mfaMethod, code)) {
-        await AuditEntry.append('failed mfa challenge', ctx, {
-          type: 'security',
+        await AuditEntry.append('Failed mfa challenge', ctx, {
+          category: 'security',
           object: user,
           user: user.id,
         });
         ctx.throw(400, 'Not a valid code');
       }
 
-      await AuditEntry.append('successfully authenticated (mfa)', ctx, {
+      await AuditEntry.append('Successfully authenticated (mfa)', ctx, {
         object: user,
         user: user.id,
       });

--- a/services/api/src/utils/middleware/application.js
+++ b/services/api/src/utils/middleware/application.js
@@ -119,7 +119,6 @@ function applicationMiddleware({ ignorePaths = [] }) {
     await ApplicationRequest.create({
       application: application.id,
       routeNormalizedPath: ctx.routerPath,
-      routePrefix: ctx.router?.opts.prefix,
       requestId,
       request: {
         ip: request.ip,

--- a/services/web/src/App.js
+++ b/services/web/src/App.js
@@ -29,6 +29,7 @@ import Loading from 'screens/Loading';
 import Error from 'screens/Error';
 import Products from 'screens/Products';
 import Applications from 'screens/Applications';
+import AuditTrail from 'screens/AuditTrail';
 
 const App = () => {
   const { loading, error } = useSession();
@@ -49,6 +50,7 @@ const App = () => {
       <Route path="/docs/ui" component={Components} exact />
       <Route path="/docs/:id?" component={Docs} />
       <Route path="/applications/:id?" component={Applications} />
+      <Route path="/audit-trail/:id?" component={AuditTrail} />
       <Route path="/logout" component={Logout} exact />
       <Route path="/login/verification" component={MfaVerification} exact />
       <Route

--- a/services/web/src/layouts/Dashboard.js
+++ b/services/web/src/layouts/Dashboard.js
@@ -84,6 +84,10 @@ export default class DashboardLayout extends React.Component {
                   scope: 'global',
                 }) && (
                   <React.Fragment>
+                    <Sidebar.Link to="/audit-trail">
+                      <Icon name="list-ol" />
+                      Audit Trail
+                    </Sidebar.Link>
                     <Sidebar.Link to="/applications">
                       <Icon name="terminal" />
                       Applications

--- a/services/web/src/modals/ShowAuditEntry.js
+++ b/services/web/src/modals/ShowAuditEntry.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import { Modal, Table, Menu, Divider } from 'semantic';
+import modal from 'helpers/modal';
+
+import CodeBlock from 'components/Markdown/Code';
+
+import { Link } from 'react-router-dom';
+import { formatDateTime } from 'utils/date';
+
+@modal
+export default class ShowAuditEntry extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      tab: 'details',
+    };
+  }
+
+  render() {
+    const { auditEntry } = this.props;
+
+    return (
+      <>
+        <Modal.Header>{auditEntry.activity}</Modal.Header>
+
+        <Modal.Content scrolling>
+          <Menu pointing secondary>
+            <Menu.Item
+              content="Details"
+              active={this.state.tab === 'details'}
+              onClick={() => this.setState({ tab: 'details' })}
+            />
+            <Menu.Item
+              disabled={!auditEntry.objectAfter || !auditEntry.objectBefore}
+              content="Modifitions"
+              active={this.state.tab === 'modifitions'}
+              onClick={() => this.setState({ tab: 'modifitions' })}
+            />
+          </Menu>
+          <Divider hidden />
+          {this.state.tab === 'details' && (
+            <>
+              <Table definition>
+                <Table.Body>
+                  <Table.Row>
+                    <Table.Cell width={4}>Activity</Table.Cell>
+                    <Table.Cell>{auditEntry.activity}</Table.Cell>
+                  </Table.Row>
+                  <Table.Row>
+                    <Table.Cell width={4}>User</Table.Cell>
+                    <Table.Cell>
+                      <Link
+                        title={auditEntry.user.email}
+                        to={`/users/${auditEntry.user.id}`}>
+                        {auditEntry.user.firstName} {auditEntry.user.firstName}
+                      </Link>
+                    </Table.Cell>
+                  </Table.Row>
+                  <Table.Row>
+                    <Table.Cell width={4}>Request Method</Table.Cell>
+                    <Table.Cell>{auditEntry.requestMethod}</Table.Cell>
+                  </Table.Row>
+                  <Table.Row>
+                    <Table.Cell width={4}>Request Url</Table.Cell>
+                    <Table.Cell>{auditEntry.requestUrl}</Table.Cell>
+                  </Table.Row>
+                  {auditEntry.objectType && (
+                    <Table.Row>
+                      <Table.Cell width={4}>Object Type</Table.Cell>
+                      <Table.Cell>{auditEntry.objectType}</Table.Cell>
+                    </Table.Row>
+                  )}
+                  {auditEntry.objectId && (
+                    <Table.Row>
+                      <Table.Cell width={4}>ObjectId</Table.Cell>
+                      <Table.Cell>{auditEntry.objectId}</Table.Cell>
+                    </Table.Row>
+                  )}
+                  <Table.Row>
+                    <Table.Cell width={4}>Created At</Table.Cell>
+                    <Table.Cell>
+                      {formatDateTime(auditEntry.createdAt)}
+                    </Table.Cell>
+                  </Table.Row>
+                </Table.Body>
+              </Table>
+            </>
+          )}
+          {this.state.tab === 'modifitions' && (
+            <>
+              <h3>Before</h3>
+              <CodeBlock
+                source={JSON.stringify(auditEntry.objectBefore || {}, null, 2)}
+                language="json"
+                allowCopy
+              />
+              <h3>After</h3>
+              <CodeBlock
+                source={JSON.stringify(auditEntry.objectAfter || {}, null, 2)}
+                language="json"
+                allowCopy
+              />
+            </>
+          )}
+        </Modal.Content>
+      </>
+    );
+  }
+}

--- a/services/web/src/screens/AuditTrail/List/index.js
+++ b/services/web/src/screens/AuditTrail/List/index.js
@@ -53,7 +53,7 @@ export default class AuditTrailList extends React.Component {
   render() {
     return (
       <Search.Provider onDataNeeded={this.onDataNeeded}>
-        {({ items, getSorted, setSort, reload }) => {
+        {({ items, getSorted, setSort }) => {
           return (
             <React.Fragment>
               <Breadcrumbs active="Organizations" />

--- a/services/web/src/screens/AuditTrail/List/index.js
+++ b/services/web/src/screens/AuditTrail/List/index.js
@@ -1,0 +1,191 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Table, Button, Segment, Divider, Label } from 'semantic';
+import { formatDateTime } from 'utils/date';
+import { request } from 'utils/api';
+import screen from 'helpers/screen';
+
+import {
+  HelpTip,
+  Breadcrumbs,
+  Layout,
+  Search,
+  SearchFilters,
+} from 'components';
+
+import ShowAuditEntry from 'modals/ShowAuditEntry';
+
+@screen
+export default class AuditTrailList extends React.Component {
+  onDataNeeded = async (params) => {
+    return await request({
+      method: 'POST',
+      path: '/1/audit-entries/search',
+      body: params,
+    });
+  };
+
+  fetchUsers = async (props) => {
+    const { data } = await request({
+      method: 'POST',
+      path: '/1/users/search',
+      body: props,
+    });
+    return data;
+  };
+
+  fetchSearchOptions = async (props) => {
+    const { data } = await request({
+      method: 'POST',
+      path: '/1/audit-entries/search-options',
+      body: props,
+    });
+    return data;
+  };
+
+  getColorForCategory = (category) => {
+    if (category === 'security') {
+      return 'orange';
+    }
+    return 'green';
+  };
+
+  render() {
+    return (
+      <Search.Provider onDataNeeded={this.onDataNeeded}>
+        {({ items, getSorted, setSort, reload }) => {
+          return (
+            <React.Fragment>
+              <Breadcrumbs active="Organizations" />
+
+              <Layout horizontal center spread>
+                <h1>Audit Trail</h1>
+                <Layout.Group></Layout.Group>
+              </Layout>
+              <Segment>
+                <Layout horizontal center spread stackable>
+                  <SearchFilters.Modal>
+                    <SearchFilters.Dropdown
+                      onDataNeeded={(name) => this.fetchUsers({ name })}
+                      search
+                      name="user"
+                      label="User"
+                    />
+                    <SearchFilters.Dropdown
+                      onDataNeeded={() =>
+                        this.fetchSearchOptions({ field: 'category' })
+                      }
+                      name="category"
+                      label="Category"
+                    />
+                    <SearchFilters.Dropdown
+                      onDataNeeded={() =>
+                        this.fetchSearchOptions({ field: 'activity' })
+                      }
+                      name="activity"
+                      label="Activity"
+                    />
+                    <SearchFilters.Dropdown
+                      onDataNeeded={() =>
+                        this.fetchSearchOptions({
+                          field: 'routeNormalizedPath',
+                        })
+                      }
+                      name="routeNormalizedPath"
+                      label="Route Normalized Path"
+                    />
+
+                    <SearchFilters.Dropdown
+                      onDataNeeded={() =>
+                        this.fetchSearchOptions({
+                          field: 'objectType',
+                        })
+                      }
+                      name="objectType"
+                      label="ObjectType"
+                    />
+                  </SearchFilters.Modal>
+                  <Layout horizontal stackable center right>
+                    <Search.Total />
+                    <SearchFilters.Search
+                      name="keyword"
+                      placeholder="Enter ObjectId"
+                    />
+                  </Layout>
+                </Layout>
+              </Segment>
+
+              <Search.Status />
+
+              {items.length !== 0 && (
+                <Table celled sortable>
+                  <Table.Header>
+                    <Table.Row>
+                      <Table.HeaderCell width={2}>User</Table.HeaderCell>
+                      <Table.HeaderCell width={1}>Category</Table.HeaderCell>
+                      <Table.HeaderCell width={4}>Activity</Table.HeaderCell>
+
+                      <Table.HeaderCell width={3}>Request</Table.HeaderCell>
+                      <Table.HeaderCell
+                        width={4}
+                        onClick={() => setSort('createdAt')}
+                        sorted={getSorted('createdAt')}>
+                        Date
+                        <HelpTip
+                          title="Created"
+                          text="This is the date and time the organization was created."
+                        />
+                      </Table.HeaderCell>
+                      <Table.HeaderCell textAlign="center">
+                        Actions
+                      </Table.HeaderCell>
+                    </Table.Row>
+                  </Table.Header>
+                  <Table.Body>
+                    {items.map((item) => {
+                      return (
+                        <Table.Row key={item.id}>
+                          <Table.Cell>
+                            <Link
+                              title={item.user.email}
+                              to={`/users/${item.user.id}`}>
+                              {item.user.firstName} {item.user.firstName} <br />
+                            </Link>
+                          </Table.Cell>
+                          <Table.Cell>
+                            <Label
+                              style={{ textTransform: 'capitalize' }}
+                              color={this.getColorForCategory(item.category)}>
+                              {item.category || 'default'}
+                            </Label>
+                          </Table.Cell>
+                          <Table.Cell>{item.activity}</Table.Cell>
+                          <Table.Cell>
+                            <code>
+                              {item.requestMethod} {item.requestUrl}
+                            </code>
+                          </Table.Cell>
+                          <Table.Cell>
+                            {formatDateTime(item.createdAt)}
+                          </Table.Cell>
+                          <Table.Cell textAlign="center">
+                            <ShowAuditEntry
+                              auditEntry={item}
+                              trigger={<Button basic icon="search" />}
+                            />
+                          </Table.Cell>
+                        </Table.Row>
+                      );
+                    })}
+                  </Table.Body>
+                </Table>
+              )}
+              <Divider hidden />
+              <Search.Pagination />
+            </React.Fragment>
+          );
+        }}
+      </Search.Provider>
+    );
+  }
+}

--- a/services/web/src/screens/AuditTrail/index.js
+++ b/services/web/src/screens/AuditTrail/index.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Switch, Route } from 'react-router-dom';
+
+import List from './List';
+
+export default class Organizations extends React.Component {
+  render() {
+    return (
+      <Switch>
+        <Route path="/audit-trail" component={List} exact />
+      </Switch>
+    );
+  }
+}


### PR DESCRIPTION
https://linear.app/bedrockdev/issue/BRC-32/add-a-crud-view-for-audit-trail

- Change the type to category, to focus more on split between just simple audit entries vs oswap worthy entries, abuse detected. Or other use cases that make sense to filter on.  
- Build out querying 
- Removed routePrefix, as it doesn't seem to be working, and perhaps not needed