### PR TITLE
Avoid defaulting upload to public when `private` is `undefined`.

### DIFF
--- a/services/api/src/utils/uploads.js
+++ b/services/api/src/utils/uploads.js
@@ -91,7 +91,7 @@ async function uploadGcs(file, upload) {
     });
   }
 
-  if (!upload.private) {
+  if (upload.private === false) {
     await gcsFile.makePublic();
   }
 }


### PR DESCRIPTION
Not sure if this is intentional but it bit me when I forgot to set the `private` property on an upload. I sort of expected it to default to `private: true`, which may not be what you guys intended. Just wanted to point this out, feel free to close if this is intentional.